### PR TITLE
Improve slide parsing

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,6 +4,7 @@ const stringifyObject = require('stringify-object')
 
 const EXREG = /export\sdefault\s\(/g
 const MODREG = /^(import|export)\s/
+const SLIDEREG = /^---\n/
 
 module.exports = async function (src) {
   const callback = this.async()
@@ -11,7 +12,7 @@ module.exports = async function (src) {
   const { data, content } = matter(src)
 
   const inlineModules = []
-  const slides = content.split('---\n')
+  const slides = content.split(SLIDEREG)
     .map(str => mdx.sync(str))
     .map(str => str.trim())
     .map(str => str.replace(EXREG, '('))

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,7 +4,7 @@ const stringifyObject = require('stringify-object')
 
 const EXREG = /export\sdefault\s\(/g
 const MODREG = /^(import|export)\s/
-const SLIDEREG = /^---\n/
+const SLIDEREG = /\n---\n/
 
 module.exports = async function (src) {
   const callback = this.async()


### PR DESCRIPTION
Currently it's not possible to use tables because they're
parsed as slides. This ensures that a slide delimiter starts
at the beginning of the line.