### PR TITLE
Fix Appear handling

### DIFF
--- a/src/Appear.js
+++ b/src/Appear.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { withSlide } from './Slide'
+import { incStep, decStep } from './index'
 
 export default withSlide(class Appear extends React.Component {
   static propTypes = {
@@ -24,13 +25,11 @@ export default withSlide(class Appear extends React.Component {
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault()
-        update(state => ({
-          step: state.step < children.length - 1 ? state.step + 1 : state.step
-        }))
+        update(incStep(children))
         break
       case 'ArrowUp':
         e.preventDefault()
-        update(state => ({ step: state.step >= 0 ? state.step - 1 : -1 }))
+        update(decStep())
         break
     }
   }

--- a/src/Appear.js
+++ b/src/Appear.js
@@ -1,9 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { withSlide } from './Slide'
 
-export default class Appear extends React.Component {
+export default withSlide(class Appear extends React.Component {
   static propTypes = {
-    children: PropTypes.array.isRequired
+    children: PropTypes.array.isRequired,
+    slide: PropTypes.object.isRequired
   }
 
   constructor(props) {
@@ -16,6 +18,12 @@ export default class Appear extends React.Component {
 
   componentDidMount() {
     document.body.addEventListener('keydown', this.handleKeyDown)
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.slide.active !== prevProps.slide.active) {
+      this.setState(state => ({ fragmentStep: -1}))
+    }
   }
 
   componentWillUnmount() {
@@ -71,4 +79,4 @@ export default class Appear extends React.Component {
       </React.Fragment>
     )
   }
-}
+})

--- a/src/Appear.js
+++ b/src/Appear.js
@@ -1,12 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { withDeck } from './context'
 import { withSlide } from './Slide'
 import { incStep, decStep } from './index'
 
-export default withSlide(class Appear extends React.Component {
+export default withDeck(withSlide(class Appear extends React.Component {
   static propTypes = {
     children: PropTypes.array.isRequired,
-    slide: PropTypes.object.isRequired
+    slide: PropTypes.object.isRequired,
+    deck: PropTypes.object.isRequired
   }
 
   componentDidMount() {
@@ -19,9 +21,9 @@ export default withSlide(class Appear extends React.Component {
 
   handleKeyDown = e => {
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
-    if (!this.props.slide.active) return
+    if (this.props.deck.index !== this.props.slide.index) return
     const { children } = this.props
-    const { update } = this.props.slide
+    const { update } = this.props.deck
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault()
@@ -36,7 +38,7 @@ export default withSlide(class Appear extends React.Component {
 
   render() {
     const { children } = this.props
-    const { step } = this.props.slide
+    const { step } = this.props.deck
     return (
       <React.Fragment>
         {children.map((fragment, index) =>
@@ -59,4 +61,4 @@ export default withSlide(class Appear extends React.Component {
       </React.Fragment>
     )
   }
-})
+}))

--- a/src/Appear.js
+++ b/src/Appear.js
@@ -8,22 +8,8 @@ export default withSlide(class Appear extends React.Component {
     slide: PropTypes.object.isRequired
   }
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      fragments: props.children,
-      fragmentStep: -1
-    }
-  }
-
   componentDidMount() {
     document.body.addEventListener('keydown', this.handleKeyDown)
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.slide.active !== prevProps.slide.active) {
-      this.setState(state => ({ fragmentStep: -1}))
-    }
   }
 
   componentWillUnmount() {
@@ -32,39 +18,34 @@ export default withSlide(class Appear extends React.Component {
 
   handleKeyDown = e => {
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+    if (!this.props.slide.active) return
+    const { children } = this.props
+    const { update } = this.props.slide
     switch (e.key) {
       case 'ArrowDown':
         e.preventDefault()
-        this.setState(state => {
-          return {
-            fragmentStep:
-              state.fragmentStep < state.fragments.length - 1
-                ? state.fragmentStep + 1
-                : state.fragmentStep
-          }
-        })
+        update(state => ({
+          step: state.step < children.length - 1 ? state.step + 1 : state.step
+        }))
         break
       case 'ArrowUp':
         e.preventDefault()
-        this.setState(state => {
-          return {
-            fragmentStep: state.fragmentStep >= 0 ? state.fragmentStep - 1 : -1
-          }
-        })
+        update(state => ({ step: state.step >= 0 ? state.step - 1 : -1 }))
         break
     }
   }
 
   render() {
-    const {fragments, fragmentStep} = this.state;
+    const { children } = this.props
+    const { step } = this.props.slide
     return (
       <React.Fragment>
-        {fragments.map((fragment, index) =>
+        {children.map((fragment, index) =>
           typeof fragment === 'string' ? (
             <div
               key={index}
               style={{
-                visibility: index <= fragmentStep ? 'visible' : 'hidden'
+                visibility: index <= step ? 'visible' : 'hidden'
               }}>
               {fragment}
             </div>
@@ -72,7 +53,7 @@ export default withSlide(class Appear extends React.Component {
             React.cloneElement(fragment, {
               key: index,
               style: {
-                visibility: index <= fragmentStep ? 'visible' : 'hidden'
+                visibility: index <= step ? 'visible' : 'hidden'
               }
             })
         ))}

--- a/src/Presenter.js
+++ b/src/Presenter.js
@@ -54,7 +54,7 @@ export const Presenter = ({
             <Zoom zoom={1/4}>
               <Root {...props}>
                 {Next && (
-                  <Slide>
+                  <Slide index={index + 1} active={true}>
                     <Next />
                   </Slide>
                 )}

--- a/src/Presenter.js
+++ b/src/Presenter.js
@@ -56,12 +56,7 @@ export const Presenter = ({
             <Zoom zoom={1/4}>
               <Root {...props}>
                 {Next && (
-                  <Slide
-                    index={index + 1}
-                    active={true}
-                    update={update}
-                    step={step}
-                  >
+                  <Slide index={index + 1}>
                     <Next />
                   </Slide>
                 )}

--- a/src/Presenter.js
+++ b/src/Presenter.js
@@ -14,6 +14,8 @@ export const Presenter = ({
   slides = [],
   mode,
   notes = {},
+  update,
+  step,
   ...props
 }) => {
   const Next = slides[index + 1]
@@ -54,7 +56,12 @@ export const Presenter = ({
             <Zoom zoom={1/4}>
               <Root {...props}>
                 {Next && (
-                  <Slide index={index + 1} active={true}>
+                  <Slide
+                    index={index + 1}
+                    active={true}
+                    update={update}
+                    step={step}
+                  >
                     <Next />
                   </Slide>
                 )}
@@ -82,6 +89,8 @@ export const Presenter = ({
 Presenter.propTypes = {
   index: PropTypes.number.isRequired,
   length: PropTypes.number.isRequired,
+  update: PropTypes.func.isRequired,
+  step: PropTypes.number.isRequired,
   slides: PropTypes.array,
   mode: PropTypes.string,
   notes: PropTypes.object

--- a/src/Slide.js
+++ b/src/Slide.js
@@ -37,13 +37,10 @@ class Slide extends React.Component {
   render () {
     const {
       index,
-      active,
-      update,
-      step,
       ...props
     } = this.props
     return (
-      <Context.Provider value={{ index, active, update, step }}>
+      <Context.Provider value={{ index }}>
         <Root {...props} />
       </Context.Provider>
     )
@@ -52,9 +49,6 @@ class Slide extends React.Component {
 
 Slide.propTypes = {
   index: PropTypes.number.isRequired,
-  active: PropTypes.bool.isRequired,
-  update: PropTypes.func.isRequired,
-  step: PropTypes.number.isRequired,
   ...space.propTypes,
   ...color.propTypes
 }

--- a/src/Slide.js
+++ b/src/Slide.js
@@ -38,10 +38,12 @@ class Slide extends React.Component {
     const {
       index,
       active,
+      update,
+      step,
       ...props
     } = this.props
     return (
-      <Context.Provider value={{ index, active }}>
+      <Context.Provider value={{ index, active, update, step }}>
         <Root {...props} />
       </Context.Provider>
     )
@@ -51,6 +53,8 @@ class Slide extends React.Component {
 Slide.propTypes = {
   index: PropTypes.number.isRequired,
   active: PropTypes.bool.isRequired,
+  update: PropTypes.func.isRequired,
+  step: PropTypes.number.isRequired,
   ...space.propTypes,
   ...color.propTypes
 }

--- a/src/Slide.js
+++ b/src/Slide.js
@@ -37,10 +37,11 @@ class Slide extends React.Component {
   render () {
     const {
       index,
+      active,
       ...props
     } = this.props
     return (
-      <Context.Provider value={{ index }}>
+      <Context.Provider value={{ index, active }}>
         <Root {...props} />
       </Context.Provider>
     )
@@ -49,6 +50,7 @@ class Slide extends React.Component {
 
 Slide.propTypes = {
   index: PropTypes.number.isRequired,
+  active: PropTypes.bool.isRequired,
   ...space.propTypes,
   ...color.propTypes
 }

--- a/src/index.js
+++ b/src/index.js
@@ -191,7 +191,8 @@ export class SlideDeck extends React.Component {
                     <Slide
                       key={i}
                       id={'slide-' + i}
-                      index={i}>
+                      index={i}
+                      active={i === index}>
                       <Component />
                     </Slide>
                   ))}

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,14 @@ export const dec = state => state.index > 0
   ? ({ index: (state.index - 1) % state.length, step: -1 })
   : null
 
+export const incStep = children => state => ({
+  step: state.step < children.length - 1 ? state.step + 1 : state.step
+})
+
+export const decStep = () => state => ({
+  step: state.step >= 0 ? state.step - 1 : -1
+})
+
 const modes = {
   normal: 'NORMAL',
   presenter: 'PRESENTER',

--- a/src/index.js
+++ b/src/index.js
@@ -34,8 +34,8 @@ export const dec = state => state.index > 0
   ? ({ index: (state.index - 1) % state.length, step: -1 })
   : null
 
-export const incStep = children => state => ({
-  step: state.step < children.length - 1 ? state.step + 1 : state.step
+export const incStep = steps => state => ({
+  step: state.step < steps.length - 1 ? state.step + 1 : state.step
 })
 
 export const decStep = () => state => ({
@@ -190,7 +190,8 @@ export class SlideDeck extends React.Component {
     const context = {
       ...this.state,
       slides,
-      addNotes: this.addNotes
+      addNotes: this.addNotes,
+      update: this.update
     }
 
     return (
@@ -215,9 +216,7 @@ export class SlideDeck extends React.Component {
                       key={i}
                       id={'slide-' + i}
                       index={i}
-                      active={i === index}
-                      update={this.update}
-                      step={step}>
+                    >
                       <Component />
                     </Slide>
                   ))}

--- a/test/index.js
+++ b/test/index.js
@@ -71,7 +71,7 @@ describe('components', () => {
   describe('Slide', () => {
     test('renders', () => {
       const json = renderJSON(
-        <Slide index={1} active={false} update={() => {}} step={-1}>
+        <Slide index={1}>
           Hi
         </Slide>
       )

--- a/test/index.js
+++ b/test/index.js
@@ -71,7 +71,7 @@ describe('components', () => {
   describe('Slide', () => {
     test('renders', () => {
       const json = renderJSON(
-        <Slide index={1} active={false}>
+        <Slide index={1} active={false} update={() => {}} step={-1}>
           Hi
         </Slide>
       )
@@ -467,6 +467,7 @@ describe('components', () => {
   color="text"
   height="100vh"
   mode="NORMAL"
+  step={-1}
   width="100vw"
 >
   <div

--- a/test/index.js
+++ b/test/index.js
@@ -14,7 +14,7 @@ const renderJSON = el => render(el).toJSON()
 describe('components', () => {
   describe('Carousel', () => {
     test('renders', () => {
-      const json = renderJSON(<Carousel>Hi</Carousel>)
+      const json = renderJSON(<Carousel index={1}>Hi</Carousel>)
       expect(json).toMatchInlineSnapshot(`
 .c0 {
   overflow-x: hidden;
@@ -36,9 +36,9 @@ describe('components', () => {
   transition-timing-function: ease-out;
   -webkit-transition-duration: .3s;
   transition-duration: .3s;
-  -webkit-transform: translateX(NaN%);
-  -ms-transform: translateX(NaN%);
-  transform: translateX(NaN%);
+  -webkit-transform: translateX(-100%);
+  -ms-transform: translateX(-100%);
+  transform: translateX(-100%);
 }
 
 @media print {
@@ -70,7 +70,11 @@ describe('components', () => {
 
   describe('Slide', () => {
     test('renders', () => {
-      const json = renderJSON(<Slide>Hi</Slide>)
+      const json = renderJSON(
+        <Slide index={1} active={false}>
+          Hi
+        </Slide>
+      )
       expect(json).toMatchInlineSnapshot(`
 .c0 {
   -webkit-flex: none;


### PR DESCRIPTION
Check if slide active status has changed and reset the steps if the status has changed. Extend `withSlide` to also provide the slide active status.