### PR TITLE
Add note about `.babelrc` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ pointing to the `.mdx` file to start the dev server:
 }
 ```
 
+Make sure you have either a global or a local Babel configuration file in place.
+
+```sh
+echo "{}" > .babelrc
+```
+
 Start the dev server:
 
 ```sh


### PR DESCRIPTION
When I first tried out the project I was getting a weird error because I didn't have a local `.babelrc` file on the project. Would be helpful if that was listed as a setup requirement.