### PR TITLE
Fixes missing Dots and navigation buttons on initial load when in normal mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist
 site
 coverage
+node_modules
+yarn.lock

--- a/src/index.js
+++ b/src/index.js
@@ -151,6 +151,7 @@ export class SlideDeck extends React.Component {
 
   getMode = () => {
     const { mode } = querystring.parse(window.location.search.replace(/^\?/, ''))
+    mode = mode || 'normal'
     this.setState({
       mode: modes[mode]
     })


### PR DESCRIPTION
The mode was being set to undefined in the `getMode` function when initially loading the application with a normal mode.  `getMode` reads the `mode` URL parameter looking for a value but the parameter is not there when in normal mode.