### PR TITLE
Correct named import of theme to default import for custom themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ It's recommended that all custom themes extend the default theme as a base.
 
 ```js
 // example theme.js
-import { theme } from 'mdx-deck/themes'
+import theme from 'mdx-deck/themes'
 
 export default {
   // extends the default theme


### PR DESCRIPTION
When I was attempting to create a custom theme and following the example, I noticed that only the new styles I was seeing were the ones I had added. No extension of the base theme was taking place. I logged out the `theme` object I was importing and found it was `undefined`. This is because `theme` is not a named export (at least not under that name). The `base` theme is exported under the `default` name in the distributed code. Thus, I corrected the documentation here to reflect the theme as a default export. This should also be done for the theme documentation, which I will do as a follow up to this PR.