### PR TITLE
Corrects named export to default export in theming documentation

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -31,7 +31,7 @@ It's recommended that all custom themes extend the default theme as a base.
 
 ```js
 // Example theme.js
-import { theme } from 'mdx-deck/themes'
+import theme from 'mdx-deck/themes'
 
 export default {
   // extends the default theme

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -112,7 +112,7 @@ Each element can be styled with a theme. Add a style object (or string) to the t
 
 ```js
 // example theme
-import { theme } from 'mdx-deck/themes'
+import theme from 'mdx-deck/themes'
 
 export default {
   ...theme,


### PR DESCRIPTION
Just as in PR #105, I have updated the docs to correctly import the base theme as a default import.