### PR TITLE
Removed comma from dev.js

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -22,7 +22,7 @@ const start = async (opts = {}) => {
   opts.dirname = opts.dirname || path.dirname(opts.entry)
   const config = createConfig(opts)
   config.entry.push(
-    path.join(__dirname, './overlay.js'),
+    path.join(__dirname, './overlay.js')
   )
 
   const middleware = await koaWebpack({


### PR DESCRIPTION
I was having issues starting the server and then saw the extra comma.

```
> npm run start

> intern-project-pres@1.0.0 start /Users/benjaminmodayil/Documents/sites/intern-project-pres
> mdx-deck deck.mdx

[mdx-deck] starting dev server
/Users/benjaminmodayil/Documents/sites/intern-project-pres/node_modules/mdx-deck/lib/dev.js:26
  )
  ^
SyntaxError: Unexpected token )
    at createScript (vm.js:53:10)
    at Object.runInThisContext (vm.js:95:10)
    at Module._compile (module.js:543:28)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/benjaminmodayil/Documents/sites/intern-project-pres/node_modules/mdx-deck/cli.js:146:11)
```