### PR TITLE
Fix slide index in Overview

### DIFF
--- a/src/Overview.js
+++ b/src/Overview.js
@@ -67,7 +67,7 @@ export const Overview = ({
         </Zoom>
         <Flex>
           <Box ml='auto' py={2}>
-            {index}/{length}
+            {index + 1}/{length}
           </Box>
         </Flex>
         <Box mt={3}>


### PR DESCRIPTION
Slide number in overview mode is using `index` so it shows `0 to n-1` but should be `1 to n`.