### PR TITLE
Add support for custom webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ See more exporting options in the [Exporting Documentation](docs/exporting.md)
 --out-file    Filename for screenshot or PDF export
 --width       Width in pixels
 --height      Height in pixels
+--webpack     Path to webpack config file
 ```
 
 ## Docs

--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const path = require('path')
 const meow = require('meow')
+const findup = require('find-up')
 const open = require('react-dev-utils/openBrowser')
 const chalk = require('chalk')
 const remark = {
@@ -24,6 +25,8 @@ const cli = meow(`
     $ ${chalk.magenta('mdx-deck screenshot deck.mdx')}
 
   ${chalk.gray('Options')}
+
+      --webpack     Path to webpack config file
 
     ${chalk.gray('Dev server options')}
 
@@ -63,6 +66,9 @@ const cli = meow(`
     html: {
       type: 'boolean',
       default: true
+    },
+    webpack: {
+      type: 'string',
     }
   }
 })
@@ -82,6 +88,12 @@ const opts = Object.assign({
 }, config, cli.flags)
 
 opts.outDir = path.resolve(opts.outDir)
+if (opts.webpack) {
+  opts.webpack = require(path.resolve(opts.webpack))
+} else {
+  const webpackConfig = findup.sync('webpack.config.js', { cwd: opts.dirname })
+  if (webpackConfig) opts.webpack = require(webpackConfig)
+}
 
 let dev
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -104,11 +104,19 @@ Webpack configuration files named `webpack.config.js` will automatically be merg
 module.exports = {
   module: {
     rules: [
-      { test: /\.svg$/, loader: 'react-svg-loader' }
+      { 
+        test: /\.svg$/, 
+        use: [
+          { loader: 'babel-loader' },
+          { loader: 'react-svg-loader' }
+        ]
+      }
     ]
   }
 }
 ```
+
+**Careful**: When overwriting the loader for `mdx` files, make sure to include the default loader from `mdx-deck/loader`.
 
 ## Custom build setups
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -95,6 +95,21 @@ Then, point the mdx-deck CLI comment in your `package.json` to the `deck.js` fil
 }
 ```
 
+## Custom webpack config
+
+Webpack configuration files named `webpack.config.js` will automatically be merged with the built-in configuration, using [webpack-merge](https://github.com/survivejs/webpack-merge). To use a custom filename, pass the file path to the `--webpack` flag.
+
+```js
+// webpack.config.js example
+module.exports = {
+  module: {
+    rules: [
+      { test: /\.svg$/, loader: 'react-svg-loader' }
+    ]
+  }
+}
+```
+
 ## Custom build setups
 
 The core mdx-deck components can also be used in any React application,

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,7 @@ const path = require('path')
 const webpack = require('webpack')
 const HTMLPlugin = require('mini-html-webpack-plugin')
 const ProgressBarPlugin = require('progress-bar-webpack-plugin')
+const merge = require('webpack-merge')
 const chalk = require('chalk')
 const remark = {
   emoji: require('remark-emoji'),
@@ -107,7 +108,7 @@ const baseConfig = {
 }
 
 const createConfig = (opts = {}) => {
-  const config = Object.assign({}, baseConfig)
+  const config = merge(baseConfig, opts.webpack)
   config.context = opts.dirname
 
   config.resolve.modules.push(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1129,6 +1129,17 @@
         "find-up": "^2.1.0",
         "istanbul-lib-instrument": "^1.10.1",
         "test-exclude": "^4.2.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        }
       }
     },
     "babel-plugin-jest-hoist": {
@@ -3507,11 +3518,43 @@
       }
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^3.0.0"
+      },
+      "dependencies": {
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        }
       }
     },
     "flush-write-stream": {
@@ -7511,6 +7554,16 @@
       "requires": {
         "find-up": "^2.0.0",
         "load-json-file": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        }
       }
     },
     "pkg-dir": {
@@ -7519,6 +7572,16 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
         "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        }
       }
     },
     "pn": {
@@ -7972,6 +8035,16 @@
       "requires": {
         "find-up": "^2.0.0",
         "read-pkg": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -9931,6 +10004,14 @@
         "uuid": "^3.1.0"
       }
     },
+    "webpack-merge": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.4.tgz",
+      "integrity": "sha512-TmSe1HZKeOPey3oy1Ov2iS3guIZjWvMT2BBJDzzT5jScHTjVC3mpjJofgueEzaEd6ibhxRDD6MIblDr8tzh8iQ==",
+      "requires": {
+        "lodash": "^4.17.5"
+      }
+    },
     "webpack-node-externals": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
@@ -10143,6 +10224,15 @@
             "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0",
             "wrap-ansi": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
           }
         },
         "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-preset-stage-0": "^6.24.1",
     "chalk": "^2.4.1",
     "clipboardy": "^1.2.3",
+    "find-up": "^3.0.0",
     "get-port": "^4.0.0",
     "gray-matter": "^4.0.1",
     "hhmmss": "^1.0.0",
@@ -67,6 +68,7 @@
     "superbox": "^2.1.0",
     "webpack": "^4.16.5",
     "webpack-hot-client": "^4.1.1",
+    "webpack-merge": "^4.1.4",
     "webpack-node-externals": "^1.7.2"
   },
   "peerDependencies": {},


### PR DESCRIPTION
Based on #112. 

## Changes

1. Add a `--webpack` option to the CLI to point to a custom config
2. Automatically look for a `webpack.config.js` from the CLI using `find-up` as [done here in x0](https://github.com/c8r/x0/blob/master/cli.js#L114-L119).
3. Use `webpack-merge` to merge with the built-in config
