### PR TITLE
Fix slide index in presenter view

### DIFF
--- a/src/Presenter.js
+++ b/src/Presenter.js
@@ -73,7 +73,7 @@ export const Presenter = ({
         </Flex>
       </Flex>
       <Flex mt='auto' px={3} py={3}>
-        <Mono>Slide {index} of {length}</Mono>
+        <Mono>Slide {index + 1} of {length}</Mono>
         <Box mx='auto' />
         <Timer />
       </Flex>


### PR DESCRIPTION
Related to #122.

Slide number in presenter mode is using `index` so it shows `0` to `n-1` but should be `1` to `n`.