### PR TITLE
WIP Focus trap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9145,6 +9145,11 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
+    "tabbable": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.1.tgz",
+      "integrity": "sha512-583MHIOwictf7+zbxqO/L5fBqMN6Li4SJ1XTKQA9WzHRA7c2BB+D+Ny7Y6kGqU2u+rHK59+oRzrBvMU53aZz+A=="
+    },
     "tapable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3566,6 +3566,15 @@
         "readable-stream": "^2.0.4"
       }
     },
+    "focus-trap": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-3.0.0.tgz",
+      "integrity": "sha512-jTFblf0tLWbleGjj2JZsAKbgtZTdL1uC48L8FcmSDl4c2vDoU4NycN1kgV5vJhuq1mxNFkw7uWZ1JAGlINWvyw==",
+      "requires": {
+        "tabbable": "^3.1.0",
+        "xtend": "^4.0.1"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "styled-components": ">=3.0.0",
     "styled-system": "^3.0.2",
     "superbox": "^2.1.0",
+    "tabbable": "^3.1.1",
     "webpack": "^4.16.5",
     "webpack-hot-client": "^4.1.1",
     "webpack-merge": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "chalk": "^2.4.1",
     "clipboardy": "^1.2.3",
     "find-up": "^3.0.0",
+    "focus-trap": "^3.0.0",
     "get-port": "^4.0.0",
     "gray-matter": "^4.0.1",
     "hhmmss": "^1.0.0",

--- a/src/FocusTrap.js
+++ b/src/FocusTrap.js
@@ -1,0 +1,63 @@
+import React from 'react'
+import tabbable from 'tabbable'
+
+export default class extends React.Component {
+  root = React.createRef()
+  active = false
+
+  handleKeyDown = e => {
+    console.log('keydown', e, this.props.index)
+  }
+
+  handleFocusIn = e => {
+    console.log('focusin', e, this.nodes)
+    e.stopImmediatePropagation()
+  }
+
+  activate = () => {
+    this.active = true
+    document.addEventListener('focusin', this.handleFocusIn, true)
+    document.addEventListener('keydown', this.handleKeyDown, true)
+    // document.addEventListener('mousedown', checkPointerDown, true)
+    // document.addEventListener('touchstart', checkPointerDown, true)
+    // document.addEventListener('click', checkClick, true)
+  }
+
+  deactivate = () => {
+    this.active = false
+    document.removeEventListener('focusin', this.handleFocusIn, true)
+    document.removeEventListener('keydown', this.handleKeyDown, true)
+  }
+
+  componentDidMount () {
+    this.nodes = tabbable(this.root.current)
+    if (this.props.active) this.activate()
+  }
+
+  componentDidUpdate () {
+    if (this.props.active) {
+      this.activate()
+    } else if (this.active) {
+      this.deactivate()
+    }
+  }
+
+  render () {
+    const {
+      children,
+      active,
+      ...props
+    } = this.props
+
+    if (active) console.log('focusTrap', props)
+    // if (!active) return children
+
+    return (
+      <div
+        ref={this.root}
+        {...props}>
+        {children}
+      </div>
+    )
+  }
+}

--- a/src/FocusTrap.js
+++ b/src/FocusTrap.js
@@ -1,43 +1,30 @@
 import React from 'react'
-import tabbable from 'tabbable'
+import createFocusTrap from 'focus-trap'
 
 export default class extends React.Component {
   root = React.createRef()
-  active = false
-
-  handleKeyDown = e => {
-    console.log('keydown', e, this.props.index)
-  }
-
-  handleFocusIn = e => {
-    console.log('focusin', e, this.nodes)
-    e.stopImmediatePropagation()
-  }
 
   activate = () => {
-    this.active = true
-    document.addEventListener('focusin', this.handleFocusIn, true)
-    document.addEventListener('keydown', this.handleKeyDown, true)
-    // document.addEventListener('mousedown', checkPointerDown, true)
-    // document.addEventListener('touchstart', checkPointerDown, true)
-    // document.addEventListener('click', checkClick, true)
+    this.trap.activate()
   }
 
   deactivate = () => {
-    this.active = false
-    document.removeEventListener('focusin', this.handleFocusIn, true)
-    document.removeEventListener('keydown', this.handleKeyDown, true)
+    this.trap.deactivate()
   }
 
   componentDidMount () {
-    this.nodes = tabbable(this.root.current)
+    this.trap = createFocusTrap(this.root.current, {
+      initialFocus: document.body,
+      fallbackFocus: document.body,
+      clickOutsideDeactivates: false,
+    })
     if (this.props.active) this.activate()
   }
 
   componentDidUpdate () {
     if (this.props.active) {
       this.activate()
-    } else if (this.active) {
+    } else {
       this.deactivate()
     }
   }
@@ -48,9 +35,6 @@ export default class extends React.Component {
       active,
       ...props
     } = this.props
-
-    if (active) console.log('focusTrap', props)
-    // if (!active) return children
 
     return (
       <div

--- a/src/Slide.js
+++ b/src/Slide.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { space, color } from 'styled-system'
 import { Context, withDeck } from './context'
+import FocusTrap from './FocusTrap'
 
-const Root = styled.div([], {
+const Root = styled(FocusTrap)([], {
   flex: 'none',
   display: 'flex',
   alignItems: 'center',
@@ -32,11 +33,14 @@ class Slide extends React.Component {
       index,
       color,
       bg,
+      active,
       ...props
     } = this.props
     return (
       <Context.Provider value={this.props}>
         <Root
+          active={active}
+          index={index}
           color={color}
           bg={bg}
           px={[ 4, 5, 6 ]}>

--- a/src/SlideDeck.js
+++ b/src/SlideDeck.js
@@ -15,6 +15,7 @@ import Presenter from './Presenter'
 import Overview from './Overview'
 import Grid from './Grid'
 import GoogleFonts from './GoogleFonts'
+import FocusTrap from './FocusTrap'
 
 import defaultTheme from './themes'
 import defaultComponents from './components'


### PR DESCRIPTION
Fixes #93 

The implementation in this branch, using [focus-trap](https://github.com/davidtheclark/focus-trap) introduces the following issues:

- [ ] Dot navigation buttons cannot be focused
- [ ] Once tabbing into a slide to focus, requires a click for keyboard shortcuts to work