### PR TITLE
Add .gitignore to basic template

### DIFF
--- a/templates/basic/.gitignore
+++ b/templates/basic/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules


### PR DESCRIPTION
When running `npm init deck path-to-deck`, the initial commit contains the entire `node_modules/` directory. This PR adds a `.gitignore` file to ignore that and the generated build files (`dist/`). 