### PR TITLE
Shrink the dot container width

### DIFF
--- a/src/Provider.js
+++ b/src/Provider.js
@@ -6,9 +6,9 @@ import { modes } from './constants'
 
 const Bottom = styled.div([], {
   position: 'fixed',
-  left: 0,
-  right: 0,
   bottom: 0,
+  left: '50%',
+  transform: 'translateX(-50%)'
 })
 
 const Button = styled.div([], {


### PR DESCRIPTION
This reduces the surface area that becomes unclickable within the window (eg; when a custom layout sticks a footer to the bottom of the viewport).

PS: I'm pretty sure this breaks the tests, but my Jest-fu isn't strong enough to figure out how to rectify it - I'd love some help there!