### PR TITLE
Allow absolute positioning within a slide

### DIFF
--- a/src/Slide.js
+++ b/src/Slide.js
@@ -13,6 +13,7 @@ const Root = styled.div([], {
   overflow: 'hidden',
   width: '100%',
   height: '100%',
+  position: 'relative',
   '@media print': {
     width: '100vw',
     height: '100vh',


### PR DESCRIPTION
Without this, anything that is given `position:absolute; left: 0` gets put at the left edge of the carousel, not the individual slide.