### PR TITLE
Support Page up/down keys

### DIFF
--- a/src/SlideDeck.js
+++ b/src/SlideDeck.js
@@ -93,10 +93,12 @@ export class SlideDeck extends React.Component {
     } else if (shift) {
       switch (e.keyCode) {
         case keys.right:
+        case keys.pgDown:
           e.preventDefault()
           this.update(incrementIndex)
           break
         case keys.left:
+        case keys.pgUp:
           e.preventDefault()
           this.update(decrementIndex)
           break
@@ -104,11 +106,13 @@ export class SlideDeck extends React.Component {
     } else if (!alt && !shift) {
       switch (e.keyCode) {
         case keys.right:
+        case keys.pgDown:
         case keys.space:
           e.preventDefault()
           this.update(next)
           break
         case keys.left:
+        case keys.pgUp:
           e.preventDefault()
           this.update(previous)
           break

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,7 +9,9 @@ export const MDX_SLIDE_STEP = 'mdx-slide-step'
 
 export const keys = {
   'right': 39,
+  'pgDown': 34,
   'left': 37,
+  'pgUp': 33,
   'space': 32,
   'p': 80,
   'o': 79,


### PR DESCRIPTION
Particularly useful when using an external clicker such as the Logitech
r400 which sends PgUp/PgDown keys for the left/right arrows.