### PR TITLE
Use single bundle to retain context for withDeck HOC

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -7,7 +7,6 @@ const {
 } = require('react-dom/server')
 const { ServerStyleSheet } = require('styled-components')
 const webpack = require('webpack')
-const nodeExternals = require('webpack-node-externals')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
 const createConfig = require('./config')
@@ -29,15 +28,6 @@ const getApp = async opts => {
     App: path.join(__dirname, '../dist/entry.js')
   }
   config.target = 'node'
-  config.externals = [
-    nodeExternals({
-      whitelist: [
-        'mdx-deck',
-        'mdx-deck/themes',
-        'mdx-deck/layouts'
-      ]
-    })
-  ]
 
   const compiler = webpack(config)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3335,7 +3335,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "^0.4.0",
@@ -7065,7 +7065,7 @@
       "dependencies": {
         "buffer": {
           "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
             "base64-js": "^1.0.2",
@@ -8003,7 +8003,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -10073,11 +10073,6 @@
       "requires": {
         "lodash": "^4.17.5"
       }
-    },
-    "webpack-node-externals": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
-      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg=="
     },
     "webpack-sources": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
     "superbox": "^2.1.0",
     "webpack": "^4.17.2",
     "webpack-hot-client": "^4.1.1",
-    "webpack-merge": "^4.1.4",
-    "webpack-node-externals": "^1.7.2"
+    "webpack-merge": "^4.1.4"
   },
   "peerDependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Fixes #171 

The issue was due to the way webpack was configured to bundle `require` calls - it was bundling all the `mdx-deck` code (including `src/context.js` which exports the `withDeck` HOC) into a single file. However, `webpack-node-externals` was used to exclude anything from `node_modules` from the bundle.

This meant if any modules in `node_modules` (such as [`mdx-deck-code-surfer`](https://github.com/pomber/code-surfer)) included `mdx-deck`, it would get a seperate, uncached instance.

ie;

```javascript
// mdx-deck/src/Notes.js
import { withDeck } from './context' // resolves to "bundled-context.js"

// node_modules/mdx-deck-code-surfer/src/deck-code-surfer.js
import { withDeck, updaters } from "mdx-deck"; // resolves to "external-context.js", a completely different instance of the same file.
```

This then means the [`React.createContext()` call](https://github.com/jxnblk/mdx-deck/blob/37999a233ee02efb15619164bc61091e1cc77230/src/context.js#L3) would be made in both `bundled-context.js` _and_ `external-context.js`, resulting in a unique `Provider`/`Consumer` pair for each. But only the `bundled-context.js`'s `<Provider>` would ever have a value set.

Ultimately, this results in the `withDeck` HOC from `external-context.js` setting `deck: null`, resulting in the error we have in #171

cc @pomber