### PR TITLE
Take out ", 10" from an if check

### DIFF
--- a/src/SlideDeck.js
+++ b/src/SlideDeck.js
@@ -153,7 +153,7 @@ export class SlideDeck extends React.Component {
       const index = parseInt(e.newValue, 10)
       this.isStorageChange = true
       this.setState({ index })
-    } else if (e.key === MDX_SLIDE_STEP, 10) {
+    } else if (e.key === MDX_SLIDE_STEP) {
       const step = parseInt(e.newValue, 10)
       this.isStorageChange = true
       this.setState({ step })


### PR DESCRIPTION
I ran into an issue when I was running a hosted version of an mdx-deck, and I think this is the cause. There were localStorage keys changing outside of these two, and I think the ", 10" in this condition was causing it to always be true.

I ran the tests and they still pass, and the demo still looked to be working. @jxnblk Were you attached to this ", 10"? Or was it just a stray bit of code?

The resulting behavior was a total crash of mdx-deck since it managed to set the step to NaN. I tried to reproduce locally by adding and changing a custom localStorage key, but it seems like the development version of react gives this warning and doesn't actually set the prop:

```
react-dom.development.js:515 Warning: Received NaN for the `step` attribute. If this is expected, cast the value to a string.
    in div (created by styled.div)
    in styled.div (created by SlideDeck)
    in div (created by Swipeable)
    in Swipeable (created by SlideDeck)
    in Provider (created by SlideDeck)
    in MDXProvider (created by SlideDeck)
    in ThemeProvider (created by SlideDeck)
    in HeadProvider (created by SlideDeck)
    in SlideDeck (created by App)
    in App
```