### PR TITLE
[Appear] "alt" prop to render only one Item at a time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdx-deck",
-  "version": "1.7.7",
+  "version": "1.8.0",
   "description": "MDX-based presentation decks",
   "main": "dist/index.js",
   "bin": {

--- a/src/Appear.js
+++ b/src/Appear.js
@@ -4,42 +4,48 @@ import { withDeck } from './context'
 import { setSteps } from './updaters'
 import { modes } from './constants'
 
-export default withDeck(class Appear extends React.Component {
-  static propTypes = {
-    children: PropTypes.array.isRequired,
-    deck: PropTypes.object.isRequired
-  }
-
-  constructor (props) {
-    super(props)
-    const { update, index } = props.deck
-    const steps = React.Children.toArray(props.children).length
-    update(setSteps(index, steps))
-  }
-
-  render() {
-    const children = React.Children.toArray(this.props.children)
-      .map(child => typeof child === 'string'
-        ? <div>{child}</div>
-        : child
-      )
-    const { step, mode } = this.props.deck
-
-    if (mode === modes.grid) {
-      return children
+export default withDeck(
+  class Appear extends React.Component {
+    static propTypes = {
+      children: PropTypes.array.isRequired,
+      alt: PropTypes.bool,
+      deck: PropTypes.object.isRequired,
     }
 
-    return (
-      <React.Fragment>
-        {children.map((child, i) => (
-          React.cloneElement(child, {
-            key: i,
-            style: {
-              visibility: (step >= i + 1) ? 'visible' : 'hidden'
-            }
-          })
-        ))}
-      </React.Fragment>
-    )
+    constructor(props) {
+      super(props)
+      const { update, index } = props.deck
+      const steps = React.Children.toArray(props.children).length
+      update(setSteps(index, steps))
+    }
+
+    render() {
+      const children = React.Children.toArray(this.props.children).map(
+        child => (typeof child === 'string' ? <div>{child}</div> : child)
+      )
+      const {
+        alt,
+        deck: { step, mode },
+      } = this.props
+
+      if (mode === modes.grid) {
+        return children
+      }
+
+      const onlyCurrentChild = (_, i) => !alt || (alt && i === step - 1)
+
+      return (
+        <React.Fragment>
+          {children.filter(onlyCurrentChild).map((child, i) =>
+            React.cloneElement(child, {
+              key: i,
+              style: {
+                visibility: step >= i + 1 ? 'visible' : 'hidden',
+              },
+            })
+          )}
+        </React.Fragment>
+      )
+    }
   }
-})
+)


### PR DESCRIPTION
# Hello!
Thanks for this tool!

<img width="100%" src="https://media.giphy.com/media/SB5Y3yYPZttx6/giphy.gif" />

## My problem 
the `Appear` children items would take their space even when invisible. That's obviously the default behaviour of the `visibility` property.

I wanted to render just one Item at a time.

with this PR, `<Appear alt>...</Appear>` will do that.

You could argue that I could have just used a `display:none` rule instead of not rendering at all the invisible elements. I preferred this solution for a couple of reasons, better match of the react lifecycle methods with the user interactions and better control of the UIs through CSS transitions/animations, eg transitions on dom append.

It's a quick PR, if you like the idea I can do some more work on it.

If you wanna test it quickly, I published [@albinotonnina/mdx-deck](https://www.npmjs.com/package/@albinotonnina/mdx-deck)

ps. Sorry for the formatting diffs. There must be something with my configuration and lint-staged on pre-commit. I guess.