### PR TITLE
Target nested lists to ensure font size is the same

### DIFF
--- a/src/themes/base.js
+++ b/src/themes/base.js
@@ -1,5 +1,3 @@
-import { inherits } from 'util'
-
 export default {
   font: 'system-ui, sans-serif',
   monospace: 'Menlo, monospace',

--- a/src/themes/base.js
+++ b/src/themes/base.js
@@ -1,9 +1,9 @@
+import { inherits } from 'util'
+
 export default {
   font: 'system-ui, sans-serif',
   monospace: 'Menlo, monospace',
-  fontSizes: [
-    '0.75em', '1em', '1.5em', '2em', '3em'
-  ],
+  fontSizes: ['0.75em', '1em', '1.5em', '2em', '3em'],
   colors: {
     text: '#000',
     background: 'white',
@@ -17,12 +17,19 @@ export default {
     textAlign: 'center',
     '@media screen and (min-width:64em)': {
       fontSize: '32px',
-    }
+    },
+    'li > ul, li > ol': {
+      fontSize: 'inherit',
+    },
+    'li > p': {
+      fontSize: 'inherit',
+      margin: 0,
+    },
   },
   ol: {
-    textAlign: 'left'
+    textAlign: 'left',
   },
   ul: {
-    textAlign: 'left'
+    textAlign: 'left',
   },
 }

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -335,6 +335,16 @@ Array [
   background-color: white;
 }
 
+.c0 li > ul,
+.c0 li > ol {
+  font-size: inherit;
+}
+
+.c0 li > p {
+  font-size: inherit;
+  margin: 0;
+}
+
 @media print {
   .c1 {
     height: auto;


### PR DESCRIPTION
Fixes the issues with nested lists where the font size would grow exponentially with each nested list. This is fixed by adding a couple of css rules into the base theme to make sure the font size of the nested lists is inherited.

Thanks @tamagokun for the example!

Nested lists before:
<img width="1392" alt="screen shot 2018-10-20 at 7 25 05 pm" src="https://user-images.githubusercontent.com/8854811/47262521-2f1b3180-d49f-11e8-8d28-dd9695846b96.png">

Nested lists after:
<img width="1392" alt="screen shot 2018-10-20 at 7 33 41 pm" src="https://user-images.githubusercontent.com/8854811/47262523-39d5c680-d49f-11e8-8cbf-91da08de1caf.png">

Fixes #198.