### PR TITLE
Fix typo in Root PropTypes.

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -1,19 +1,20 @@
 import styled from 'styled-components'
-import {
-  width,
-  height,
-  color
-} from 'styled-system'
+import { width, height, color } from 'styled-system'
 
-export const Root = styled.div([], {
-  '@media print': {
-    fontSize: '24px',
-    height: 'auto'
+export const Root = styled.div(
+  [],
+  {
+    '@media print': {
+      fontSize: '24px',
+      height: 'auto',
+    },
   },
-},
-  props => props.theme.font ? ({
-    fontFamily: props.theme.font
-  }) : null,
+  props =>
+    props.theme.font
+      ? {
+          fontFamily: props.theme.font,
+        }
+      : null,
   props => props.theme.css,
   width,
   height,
@@ -23,12 +24,12 @@ export const Root = styled.div([], {
 Root.propTypes = {
   ...width.propTypes,
   ...height.propTypes,
-  ...color.propTypess
+  ...color.propTypes,
 }
 
 Root.defaultProps = {
   color: 'text',
-  bg: 'background'
+  bg: 'background',
 }
 
 export default Root


### PR DESCRIPTION
Thanks for a great library! This PR fixes a small typo I noticed in `Root`s `PropTypes` while reading the `mdx-deck` source. The pre-commit hook seems to have altered some formatting, but the essential change happens on L27 of the diff (just removing a stray "s").