### PR TITLE
Allow overflow for FullScreenCode

### DIFF
--- a/src/layouts/FullScreenCode.js
+++ b/src/layouts/FullScreenCode.js
@@ -10,6 +10,7 @@ const FullCode = styled.div([], {
     margin: '0 !important',
     width: '100vw',
     height: '100vh',
+    overflow: 'auto',
   }
 })
 


### PR DESCRIPTION
In cases where code sample is too large for the slide, presenters can now scroll to show more.