### PR TITLE
Fix Appear children PropTypes

### DIFF
--- a/src/Appear.js
+++ b/src/Appear.js
@@ -6,7 +6,7 @@ import { modes } from './constants'
 
 export default withDeck(class Appear extends React.Component {
   static propTypes = {
-    children: PropTypes.array.isRequired,
+    children: PropTypes.node.isRequired,
     deck: PropTypes.object.isRequired
   }
 


### PR DESCRIPTION
Hi,

`Appear` children can be a single element so PropTypes should not required an array