### PR TITLE
[Appear] keep style of children if exists

### DIFF
--- a/src/Appear.js
+++ b/src/Appear.js
@@ -35,6 +35,7 @@ export default withDeck(class Appear extends React.Component {
           React.cloneElement(child, {
             key: i,
             style: {
+              ...((child.props || {}).style || {})
               visibility: (step >= i + 1) ? 'visible' : 'hidden'
             }
           })

--- a/src/Appear.js
+++ b/src/Appear.js
@@ -35,7 +35,7 @@ export default withDeck(class Appear extends React.Component {
           React.cloneElement(child, {
             key: i,
             style: {
-              ...((child.props || {}).style || {})
+              ...((child.props || {}).style || {}),
               visibility: (step >= i + 1) ? 'visible' : 'hidden'
             }
           })


### PR DESCRIPTION
Currenly,`<Appear/>` set its children style props to `{ visibility: ... }`

With this PR, if a child had a pre-existing style, it will be kept