### PR TITLE
Upgrade remark-unwrap-images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9211,11 +9211,11 @@
       }
     },
     "remark-unwrap-images": {
-      "version": "0.0.2-0",
-      "resolved": "https://registry.npmjs.org/remark-unwrap-images/-/remark-unwrap-images-0.0.2-0.tgz",
-      "integrity": "sha512-6MSgeb6mFM5Hrc/ZvHz9SDAYF8cl6sU45PTgWye/XDgr+AIUT5CTprJrbJH3LNnZSvmU7j3wOVAJlerWv/sNag==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/remark-unwrap-images/-/remark-unwrap-images-0.1.0.tgz",
+      "integrity": "sha512-70j4Qy6Mj2+0MmQOmSES40+hO4BQGm2hhb5qNq8LwTlGrmyE4VWsKPIryELiBK0TZP57crOkSOD/AFqPjxvekQ==",
       "requires": {
-        "unist-util-visit": "^1.3.0"
+        "unist-util-visit-parents": "^2.0.1"
       }
     },
     "remove-trailing-separator": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-swipeable": "^4.3.0",
     "react-syntax-highlighter": "^8.1.0",
     "remark-emoji": "^2.0.2",
-    "remark-unwrap-images": "0.0.2-0",
+    "remark-unwrap-images": "^0.1.0",
     "rimraf": "^2.6.2",
     "stringify-object": "^3.3.0",
     "styled-components": "^3.4.10",


### PR DESCRIPTION
Hello : )

I found that copy/pasting markdown links to [CodeSandbox](https://codesandbox.io/) (and, in general, using images wrapped in links) wasn't working as expected, so [I fixed it](https://github.com/johno/remark-unwrap-images/pull/2).

I hope this is OK to merge.

Thank you very much!