### PR TITLE
Make sure window exists before using it

### DIFF
--- a/src/Appear.js
+++ b/src/Appear.js
@@ -29,7 +29,7 @@ export default withDeck(class Appear extends React.Component {
       return children
     }
 
-    if (window.navigator.userAgent.includes('Print/PDF')) {
+    if (typeof window !== 'undefined' && window.navigator.userAgent.includes('Print/PDF')) {
       return children;
     }
 


### PR DESCRIPTION
Addresses https://github.com/jxnblk/mdx-deck/issues/233 where building a deck fails because `window` doesn't exist in Node.js.