### PR TITLE
Support .jsx components

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,7 +7,7 @@ const merge = require('webpack-merge')
 const chalk = require('chalk')
 const remark = {
   emoji: require('remark-emoji'),
-  unwrapImages: require('remark-unwrap-images')
+  unwrapImages: require('remark-unwrap-images'),
 }
 
 const babel = {
@@ -16,26 +16,22 @@ const babel = {
     'babel-preset-stage-0',
     'babel-preset-react',
   ].map(require.resolve),
-  plugins: [
-    'babel-plugin-styled-components'
-  ].map(require.resolve)
+  plugins: ['babel-plugin-styled-components'].map(require.resolve),
 }
 
 const rules = [
   {
-    test: /\.js$/,
+    test: /\.jsx?$/,
     exclude: /node_modules/,
     loader: require.resolve('babel-loader'),
-    options: babel
+    options: babel,
   },
   {
     test: /\.js$/,
     exclude: path.resolve(__dirname, '../node_modules'),
-    include: [
-      path.resolve(__dirname, '..'),
-    ],
+    include: [path.resolve(__dirname, '..')],
     loader: require.resolve('babel-loader'),
-    options: babel
+    options: babel,
   },
   {
     test: /\.mdx?$/,
@@ -43,19 +39,16 @@ const rules = [
     use: [
       {
         loader: require.resolve('babel-loader'),
-        options: babel
+        options: babel,
       },
       {
         loader: require.resolve('./loader.js'),
         options: {
-          mdPlugins: [
-            remark.emoji,
-            remark.unwrapImages
-          ]
-        }
-      }
-    ]
-  }
+          mdPlugins: [remark.emoji, remark.unwrapImages],
+        },
+      },
+    ],
+  },
 ]
 
 const template = ({
@@ -63,7 +56,7 @@ const template = ({
   css = '',
   body = '',
   js,
-  publicPath
+  publicPath,
 }) => `<!DOCTYPE html>
 <html>
 <head>
@@ -84,16 +77,17 @@ const baseConfig = {
   stats: 'errors-only',
   mode: 'development',
   module: {
-    rules
+    rules,
   },
   resolve: {
+    extensions: ['.js', '.jsx'],
     alias: {
-      'mdx-deck': path.resolve(__dirname, '..')
+      'mdx-deck': path.resolve(__dirname, '..'),
     },
     modules: [
       path.relative(process.cwd(), path.join(__dirname, '../node_modules')),
-      'node_modules'
-    ]
+      'node_modules',
+    ],
   },
   plugins: [
     new ProgressBarPlugin({
@@ -107,8 +101,8 @@ const baseConfig = {
       ].join(' '),
       summary: false,
       customSummary: () => {},
-    })
-  ]
+    }),
+  ],
 }
 
 const createConfig = (opts = {}) => {
@@ -120,14 +114,12 @@ const createConfig = (opts = {}) => {
     path.join(opts.dirname, 'node_modules')
   )
 
-  config.entry = [
-    path.join(__dirname, '../dist/entry.js')
-  ]
+  config.entry = [path.join(__dirname, '../dist/entry.js')]
 
   const defs = Object.assign({}, opts.globals, {
     OPTIONS: JSON.stringify(opts),
     HOT_PORT: JSON.stringify(opts.hotPort),
-    HOT_HOST: JSON.stringify(opts.host)
+    HOT_HOST: JSON.stringify(opts.host),
   })
 
   config.plugins.push(


### PR DESCRIPTION
This adds support for importing components with a .jsx file extension. Webpack will also resolve these if no extension is provided.

For example:
import FancyComponent from './components/Fancy'
(will resolve to either Fancy.js and Fancy.jsx)

Solves #231
Cleaned up version of #237 