### PR TITLE
Add mdx-deck-live-code as external library

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ These third-party libraries are great for use with mdx-deck.
 
 - [CodeSurfer][]: React component for scrolling, zooming and highlighting code.
 - [mdx-code][]: Runnable code playgrounds for MDX Deck.
+- [mdx-deck-live-code][]: Live React and JS coding in slides.
 
 [codesurfer]: https://github.com/pomber/code-surfer
 [mdx-code]: https://github.com/pranaygp/mdx-code
+[mdx-deck-live-code]: https://github.com/JReinhold/mdx-deck-live-code
 
 ### Layouts
 


### PR DESCRIPTION
Thanks for mdx-deck, it is really awesome!

I made this library to do live React and JS coding in the slides. I would be honoured to be mentioned in the Readme.
I would also really appreciate some feedback from anyone who has time someday.

repo: https://github.com/JReinhold/mdx-deck-live-code
demo: https://reinhold.is/live-coding-in-slides
