### PR TITLE
Fix default language for syntax highlighting

### DIFF
--- a/src/Code.js
+++ b/src/Code.js
@@ -1,44 +1,47 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { withTheme } from 'styled-components'
-import SyntaxHighlighter, { registerLanguage } from 'react-syntax-highlighter/prism-light'
+import SyntaxHighlighter, {
+  registerLanguage,
+} from 'react-syntax-highlighter/prism-light'
 import defaultTheme from 'react-syntax-highlighter/styles/prism/atom-dark'
 import javascript from 'react-syntax-highlighter/languages/prism/javascript'
 import jsx from 'react-syntax-highlighter/languages/prism/jsx'
 
-export default withTheme(class Code extends React.Component {
-  static propTypes = {
-    children: PropTypes.string,
-    className: PropTypes.string,
-    theme: PropTypes.object
-  }
+export default withTheme(
+  class Code extends React.Component {
+    static propTypes = {
+      children: PropTypes.string,
+      className: PropTypes.string,
+      theme: PropTypes.object,
+    }
 
-  constructor(props) {
-    super(props)
-    registerLanguage('javascript', javascript)
-    registerLanguage('jsx', jsx)
-    if (props.theme && props.theme.prism && props.theme.prism.languages) {
-      const languages = props.theme.prism.languages
-      Object.keys(languages).forEach(key => {
-        registerLanguage(key, languages[key])
-      })
+    constructor(props) {
+      super(props)
+      registerLanguage('javascript', javascript)
+      registerLanguage('jsx', jsx)
+      if (props.theme && props.theme.prism && props.theme.prism.languages) {
+        const languages = props.theme.prism.languages
+        Object.keys(languages).forEach(key => {
+          registerLanguage(key, languages[key])
+        })
+      }
+    }
+
+    getLanguage = lang => {
+      return lang ? lang.replace('language-', '') : 'javascript'
+    }
+
+    render() {
+      const { className, children, theme } = this.props
+      const language = this.getLanguage(className)
+      const style =
+        theme.prism && theme.prism.style ? theme.prism.style : defaultTheme
+      return (
+        <SyntaxHighlighter language={language} style={style}>
+          {children}
+        </SyntaxHighlighter>
+      )
     }
   }
-
-  getLangauge = (lang) => {
-    return lang ? lang.replace('language-', '') : 'javascripts'
-  }
-
-  render() {
-    const { className, children, theme } = this.props
-    const language = this.getLangauge(className)
-    const style = (theme.prism && theme.prism.style)
-      ? theme.prism.style
-      : defaultTheme
-    return (
-      <SyntaxHighlighter language={language} style={style}>
-        {children}
-      </SyntaxHighlighter>
-    )
-  }
-})
+)


### PR DESCRIPTION
I apologize for the big change here, it seems that prettier has not been run on these files, but is now being applied in a precommit hook?

Anyway:

This fixes a tiny little bug where the default language in the `<Code />` component uses the string `javascripts` instead of `javascript`. It also fixes a typo: `getLangauge` => `getLanguage`.