### PR TITLE
Include prism styling by default

### DIFF
--- a/src/themes/base.js
+++ b/src/themes/base.js
@@ -1,9 +1,9 @@
+import okaidia from 'react-syntax-highlighter/dist/styles/prism/okaidia'
+
 export default {
   font: 'system-ui, sans-serif',
   monospace: 'Menlo, monospace',
-  fontSizes: [
-    '0.75em', '1em', '1.5em', '2em', '3em'
-  ],
+  fontSizes: ['0.75em', '1em', '1.5em', '2em', '3em'],
   colors: {
     text: '#000',
     background: 'white',
@@ -17,12 +17,15 @@ export default {
     textAlign: 'center',
     '@media screen and (min-width:64em)': {
       fontSize: '32px',
-    }
+    },
   },
   ol: {
-    textAlign: 'left'
+    textAlign: 'left',
   },
   ul: {
-    textAlign: 'left'
+    textAlign: 'left',
+  },
+  prism: {
+    style: okaidia,
   },
 }


### PR DESCRIPTION
This is a bit opinionated, I realize, but it seems weird to me that there is no syntax highlighting styles included by default. It wasn't super clear to me how to add it, and after finding the solution, I feel like it is perhaps a bit more work than necessary:

- Add a `theme.js`
- Figure out the path and import of the default theme
- Figure out the path and import a prism styling config
- Spread the default styles onto the export
- Add an export declaration for the theme in the deck

Since the actual syntax highlighting for JS/JSX is being included by default, it seems a bit of an add odd choice not to also include a theme so that it "just works", but can still be configured.

I investigated how many extra bytes it would add to include the `okaidia` theme:
```
Approximate weight of react-syntax-highlighter/dist/styles/prism/okaidia:
  Uncompressed: 3.91 kB
  Minified (uglify): 2.47 kB
  Minified and gzipped (level: default): 973 B
```

Which doesn't seem like much to me, compared to the convenience it gives.

I don't have any strong feelings on which theme should be used, I just picked one I personally found pleasing. The other changes in this PR is due to prettier being applied in a precommit stage.