### PR TITLE
Surface compilation errors from webpack

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -30,6 +30,12 @@ const build = async (opts = {}) => {
         reject(err)
         return
       }
+
+      if (stats.compilation.errors && stats.compilation.errors.length) {
+        reject(stats.compilation.errors);
+        return;
+      }
+
       resolve(stats)
     })
   })


### PR DESCRIPTION
For example, I was hit by this bug: https://github.com/webpack-contrib/terser-webpack-plugin/issues/66 And mdx-deck was silently failing (and worse; making it look like it was successful).

This patch will guard against these kinds of issues in the future.

The complete error I managed to expose was:

```
Error: main.js from Terser
  TypeError: Cannot read property 'minify' of undefined
      at minify (<path>/node_modules/terser-webpack-plugin/dist/minify.js:175:23)
      at module.exports (<path>/node_modules/terser-webpack-plugin/dist/worker.js:13:40)
      at handle (<path>/node_modules/worker-farm/lib/child/index.js:44:8)
      at process.<anonymous> (<path>/node_modules/worker-farm/lib/child/index.js:51:3)
      at process.emit (events.js:182:13)
      at emit (internal/child_process.js:811:12)
      at process._tickCallback (internal/process/next_tick.js:63:19)
      at Function.buildError (<path>/node_modules/terser-webpack-plugin/dist/index.js:103:14)
      at results.forEach (<path>/node_modules/terser-webpack-plugin/dist/index.js:255:50)
      at Array.forEach (<anonymous>)
      at taskRunner.run (<path>/node_modules/terser-webpack-plugin/dist/index.js:230:17)
      at step (<path>/node_modules/terser-webpack-plugin/dist/TaskRunner.js:83:9)
      at done (<path>/node_modules/terser-webpack-plugin/dist/TaskRunner.js:94:30)
      at boundWorkers (<path>/node_modules/terser-webpack-plugin/dist/TaskRunner.js:99:13)
      at <path>/node_modules/worker-farm/lib/farm.js:191:19
      at process._tickCallback (internal/process/next_tick.js:61:11) ]
```