### PR TITLE
Prevent Appear from resetting when changing slides

### DIFF
--- a/src/Appear.js
+++ b/src/Appear.js
@@ -11,10 +11,21 @@ export default withDeck(
       deck: PropTypes.object.isRequired,
     }
 
+    static getDerivedStateFromProps(props) {
+      const { deck } = props
+      if (!deck.active) return null
+      return {
+        step: deck.step,
+      }
+    }
+
     constructor(props) {
       super(props)
       const { update, index } = props.deck
       const steps = React.Children.toArray(props.children).length
+      this.state = {
+        step: 0,
+      }
       update(setSteps(index, steps))
     }
 
@@ -22,7 +33,7 @@ export default withDeck(
       const children = React.Children.toArray(this.props.children).map(child =>
         typeof child === 'string' ? <div>{child}</div> : child
       )
-      const { step, mode } = this.props.deck
+      const { mode } = this.props.deck
 
       if (mode === modes.grid) {
         return children
@@ -34,6 +45,8 @@ export default withDeck(
       ) {
         return children
       }
+
+      const { step } = this.state
 
       return (
         <React.Fragment>

--- a/src/Appear.js
+++ b/src/Appear.js
@@ -19,8 +19,8 @@ export default withDeck(
     }
 
     render() {
-      const children = React.Children.toArray(this.props.children).map(
-        child => (typeof child === 'string' ? <div>{child}</div> : child)
+      const children = React.Children.toArray(this.props.children).map(child =>
+        typeof child === 'string' ? <div>{child}</div> : child
       )
       const { step, mode } = this.props.deck
 


### PR DESCRIPTION
Howdy! First-time contributor here.

Currently, `Appear` resets to the first step when you change slides, causing its content to disappear during the transition to the next slide. You can see this [in the demo deck](https://jxnblk.com/mdx-deck/#9.4):

![appear-glitch](https://user-images.githubusercontent.com/224895/52318904-be881a00-2994-11e9-972d-3478d3c98907.gif)

This is caused by `Appear` receiving a new `deck` object with `step={0}` when the transition occurs. The fix in this PR is to have `Appear` ignore new `step` values when the `deck` it receives has `active={false}`.

Please let me know if there's anything else you need from me here.