### PR TITLE
Take loaders in account when merging webpack configs

### DIFF
--- a/packages/mdx-deck/lib/config.js
+++ b/packages/mdx-deck/lib/config.js
@@ -76,7 +76,7 @@ const baseConfig = {
 }
 
 const createConfig = (opts = {}) => {
-  const config = merge(baseConfig, opts.webpack)
+  const config = merge.smart(baseConfig, opts.webpack)
   config.context = opts.dirname
 
   config.resolve.modules.push(


### PR DESCRIPTION
This change adds the ability to redefine configurations of webpack loaders that are set by internal config.

For example, to use additional remark plugins they should be passed to mdx-loader. Currently, it is not possible to manually configure mdx-loader since it always set by internal webpack config and if we add it into own config then two instances of mdx-loader will be configured.