### PR TITLE
Grid/Overview/Presenter props fix

### DIFF
--- a/docs/CodeStepper.js
+++ b/docs/CodeStepper.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { atomDark as codeStyle } from 'react-syntax-highlighter/dist/esm/styles/prism'
+import { css } from '@emotion/core'
+
+import { useSteps } from '@mdx-deck/components'
+
+const CodeStepper = ({ code, steps, title = '', language = '' }) => {
+  const step = useSteps(steps.length - 1)
+  const current = steps[step]
+
+  return (
+    <>
+      <span
+        css={css`
+          font-size: 2rem;
+          color: #bbbbbb;
+        `}
+      >
+        {title}
+      </span>
+      <SyntaxHighlighter
+        style={codeStyle}
+        language={language}
+        wrapLines
+        lineProps={currentLine => ({
+          style: {
+            opacity: `${current.indexOf(currentLine) >= 0 ? 1 : 0.3}`,
+          },
+        })}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </>
+  )
+}
+
+export default CodeStepper

--- a/docs/demo.mdx
+++ b/docs/demo.mdx
@@ -2,6 +2,7 @@ export { future as theme } from '@mdx-deck/themes'
 import { Head, Image, Notes, Appear } from '@mdx-deck/components'
 import { Invert, Split, SplitRight, FullScreenCode, Horizontal} from '@mdx-deck/layouts'
 import Counter from './Counter'
+import CodeStepper from './CodeStepper'
 
 <Head>
   <title>mdx-deck</title>
@@ -168,6 +169,22 @@ export default FullScreenCode
 ![](https://images.unsplash.com/photo-1462331940025-496dfbfc7564?w=2048&h=1024&q=20&fit=crop)
 
 Inline image
+
+---
+
+Use the `useSteps` hook to create custom stepping components
+
+<CodeStepper
+  code={`<Button>
+  Beep
+</Button>`}
+  language='jsx'
+  title='CodeStepper'
+  steps={[
+    [1,3],
+    [2],
+  ]}
+/>
 
 ---
 

--- a/packages/components/src/Grid.js
+++ b/packages/components/src/Grid.js
@@ -64,7 +64,7 @@ export const Grid = withLocation(props => {
             }}
           >
             <Zoom zoom={1 / 4}>
-              <Slide>
+              <Slide index={i} path={`/${i}`} step={0} mode={modes.GRID}>
                 <Component />
               </Slide>
             </Zoom>

--- a/packages/components/src/MDXDeck.js
+++ b/packages/components/src/MDXDeck.js
@@ -11,19 +11,7 @@ import Grid from './Grid'
 import Print from './Print'
 import GoogleFonts from './GoogleFonts'
 import Catch from './Catch'
-
-const NORMAL = 'normal'
-const PRESENTER = 'presenter'
-const OVERVIEW = 'overview'
-const GRID = 'grid'
-const PRINT = 'print'
-const modes = {
-  NORMAL,
-  PRESENTER,
-  OVERVIEW,
-  GRID,
-  PRINT,
-}
+import modes from './modes'
 
 const STORAGE_INDEX = 'mdx-slide'
 const STORAGE_STEP = 'mdx-step'
@@ -38,7 +26,7 @@ const keys = {
 }
 
 const toggleMode = key => state => ({
-  mode: state.mode === key ? NORMAL : key,
+  mode: state.mode === key ? modes.NORMAL : key,
 })
 
 const BaseWrapper = props => <>{props.children}</>
@@ -52,7 +40,7 @@ export class MDXDeck extends React.Component {
     this.state = {
       slides: props.slides,
       step: 0,
-      mode: NORMAL,
+      mode: modes.NORMAL,
       update: fn => this.setState(fn),
     }
   }
@@ -77,13 +65,13 @@ export class MDXDeck extends React.Component {
     if (alt) {
       switch (keyCode) {
         case keys.p:
-          this.setState(toggleMode(PRESENTER))
+          this.setState(toggleMode(modes.PRESENTER))
           break
         case keys.o:
-          this.setState(toggleMode(OVERVIEW))
+          this.setState(toggleMode(modes.OVERVIEW))
           break
         case keys.g:
-          this.setState(toggleMode(GRID))
+          this.setState(toggleMode(modes.GRID))
           break
       }
     } else {
@@ -196,7 +184,7 @@ export class MDXDeck extends React.Component {
     const { step, mode } = this.state
     localStorage.setItem(STORAGE_INDEX, index)
     localStorage.setItem(STORAGE_STEP, step)
-    if (mode !== NORMAL && mode !== PRINT) {
+    if (mode !== modes.NORMAL && mode !== modes.PRINT) {
       const query = '?' + querystring.stringify({ mode })
       navigate(query)
     } else {
@@ -213,7 +201,7 @@ export class MDXDeck extends React.Component {
   render() {
     const { pathname } = globalHistory.location
     const { slides } = this.state
-    const mode = pathname === '/print' ? PRINT : this.state.mode
+    const mode = pathname === '/print' ? modes.PRINT : this.state.mode
     const index = this.getIndex()
     const meta = this.getMeta(index)
     const context = {
@@ -225,13 +213,13 @@ export class MDXDeck extends React.Component {
 
     let Wrapper = BaseWrapper
     switch (mode) {
-      case PRESENTER:
+      case modes.PRESENTER:
         Wrapper = Presenter
         break
-      case OVERVIEW:
+      case modes.OVERVIEW:
         Wrapper = Overview
         break
-      case GRID:
+      case modes.GRID:
         Wrapper = Grid
         break
     }

--- a/packages/components/src/Overview.js
+++ b/packages/components/src/Overview.js
@@ -17,7 +17,7 @@ const withLocation = Component => props => (
 )
 
 export const Overview = withLocation(props => {
-  const { index, slides } = props
+  const { index, slides, modes } = props
   const activeThumb = React.createRef()
 
   useEffect(() => {
@@ -68,7 +68,7 @@ export const Overview = withLocation(props => {
             }}
           >
             <Zoom zoom={1 / 6}>
-              <Slide>
+              <Slide index={i} path={`/${i}`} step={0} mode={modes.OVERVIEW}>
                 <Component />
               </Slide>
             </Zoom>

--- a/packages/components/src/Presenter.js
+++ b/packages/components/src/Presenter.js
@@ -6,7 +6,7 @@ import Pre from './Pre'
 import Clock from './Clock'
 
 export const Presenter = props => {
-  const { slides, index } = props
+  const { slides, index, modes } = props
   const Current = slides[index]
   const Next = slides[index + 1]
   const { notes } = Current.meta || {}
@@ -48,7 +48,12 @@ export const Presenter = props => {
         >
           <Zoom zoom={1 / 4}>
             {Next && (
-              <Slide>
+              <Slide
+                index={index}
+                path={`/${index}`}
+                step={0}
+                mode={modes.PRESENTER}
+              >
                 <Next />
               </Slide>
             )}

--- a/packages/components/src/Slide.js
+++ b/packages/components/src/Slide.js
@@ -1,7 +1,9 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 import Root from './Root'
 import { Context } from './context'
+import modes from './modes'
 
 const SlideRoot = styled.div(
   {
@@ -23,5 +25,12 @@ export const Slide = ({ children, ...props }) => (
     </Root>
   </Context.Provider>
 )
+
+Slide.propTypes = {
+  path: PropTypes.string.isRequired,
+  index: PropTypes.number.isRequired,
+  step: PropTypes.number.isRequired,
+  mode: PropTypes.oneOf(Object.values(modes)).isRequired,
+}
 
 export default Slide

--- a/packages/components/src/modes.js
+++ b/packages/components/src/modes.js
@@ -1,0 +1,15 @@
+const NORMAL = 'normal'
+const PRESENTER = 'presenter'
+const OVERVIEW = 'overview'
+const GRID = 'grid'
+const PRINT = 'print'
+
+const modes = {
+  NORMAL,
+  PRESENTER,
+  OVERVIEW,
+  GRID,
+  PRINT,
+}
+
+export default modes

--- a/yarn.lock
+++ b/yarn.lock
@@ -8259,10 +8259,10 @@ remark-squeeze-paragraphs@^3.0.1:
   dependencies:
     mdast-squeeze-paragraphs "^3.0.0"
 
-remark-unwrap-images@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/remark-unwrap-images/-/remark-unwrap-images-0.1.0.tgz#b5487b2af9544cb72ff080bc092b37778a9dd671"
-  integrity sha512-70j4Qy6Mj2+0MmQOmSES40+hO4BQGm2hhb5qNq8LwTlGrmyE4VWsKPIryELiBK0TZP57crOkSOD/AFqPjxvekQ==
+remark-unwrap-images@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/remark-unwrap-images/-/remark-unwrap-images-0.2.0.tgz#d2480a849d824b25d3b693944b4d4d2bbe03f887"
+  integrity sha512-4BLvJgT46ZNAJYr2Ibg37HjSESb/iHdUz/ms25psZu7ta/GDyk/5bXR+9w/YFx9phSpNduP+mb+QE0VDExlHnA==
   dependencies:
     unist-util-visit-parents "^2.0.1"
 


### PR DESCRIPTION
- Update Slide to include PropTypes to make sure the correct props are
passed
- Move modes to their file so that they can be referenced from another
file
- Update docs demo to include a component that uses the `useSteps`
hooks. This should catch any regression until tests can be created
- Update Grid, Presenter, and Overview to correctly pass in the required
props to Slide defined by its PropTypes

fixes #297