### PR TITLE
fix: reset notes on every step

### DIFF
--- a/packages/components/src/MDXDeck.js
+++ b/packages/components/src/MDXDeck.js
@@ -110,6 +110,7 @@ export const MDXDeck = props => {
     const { search } = globalHistory.location
     navigate(basepath + '/' + nextIndex + search)
     const meta = getMeta(nextIndex)
+    meta.notes = ''
     setState({
       step: reverse ? meta.steps || 0 : 0,
     })
@@ -119,6 +120,7 @@ export const MDXDeck = props => {
     const current = getIndex(props)
     const meta = getMeta(current)
     if (meta.steps && state.step > 0) {
+      meta.notes = ''
       setState({ step: state.step - 1 })
     } else {
       const p = current - 1
@@ -131,6 +133,7 @@ export const MDXDeck = props => {
     const current = getIndex(props)
     const meta = getMeta(current)
     if (meta.steps && state.step < meta.steps) {
+      meta.notes = ''
       setState({ step: state.step + 1 })
     } else {
       const n = current + 1

--- a/packages/components/src/Notes.js
+++ b/packages/components/src/Notes.js
@@ -1,15 +1,31 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { useDeck } from './context'
+import { useStep } from './useStep'
 
 export const Notes = props => {
   const context = useDeck()
+  if (!context || !context.register) {
+    // The slide was rendered as a preview by the <Presenter> component.
+    return false
+  }
+
+  const index = useRef(context.index).current
+  const step = useStep()
   useEffect(() => {
-    if (!context || !context.register) return
-    if (typeof context.index === 'undefined') return
-    context.register(context.index, {
+    // The context changes before this component is unmounted.
+    if (context.index !== index) return
+    // Only render notes for the current step.
+    if (context.step !== step) return
+
+    // Only re-render if the notes changed.
+    const meta = context.metadata[index] || {}
+    if (meta.notes === props.children) return
+
+    // Note: The last <Notes/> per slide always takes precedence.
+    context.register(index, {
       notes: props.children,
     })
-  }, [])
+  })
 
   return false
 }

--- a/packages/components/src/Steps.js
+++ b/packages/components/src/Steps.js
@@ -1,10 +1,30 @@
 import React from 'react'
 import { useDeck } from './context'
 import useSteps from './useSteps'
+import { Step } from './useStep'
 
-export const Steps = props => {
-  const step = useSteps(props.length)
-  return props.render({ step })
+export const Steps = ({ items, render, ...props }) => {
+  const step = useSteps(items ? items.length : props.length)
+  return items ? (
+    <div>
+      {items.map((item, i) => {
+        const visible = props.split ? step === i : step >= i
+        return (
+          visible && (
+            <Step key={i} index={i}>
+              {render
+                ? render(item, i)
+                : typeof item === 'function'
+                ? item(i)
+                : item}
+            </Step>
+          )
+        )
+      })}
+    </div>
+  ) : (
+    render({ step })
+  )
 }
 
 export default Steps

--- a/packages/components/src/useStep.js
+++ b/packages/components/src/useStep.js
@@ -1,0 +1,11 @@
+import { useContext, createContext } from 'react'
+
+const StepContext = createContext(0)
+
+export const useStep = () => useContext(StepContext)
+
+export const Step = props => (
+  <StepContext.Provider value={props.index}>
+    {props.children}
+  </StepContext.Provider>
+)


### PR DESCRIPTION
This ensures that the proper notes are shown when navigating backwards. To accomplish this, I've added an `items` prop to the `<Steps>` component. Each item is wrapped in the new `<Step>` component in order to ensure that every `<Notes>` component has access to its associated step. Finally, reset `meta.notes` to an empty string on every slide/step change.

If you have a better solution in mind, let me know! 👍 

It also allows for per-step notes:

```js
import {Steps} from 'mdx-deck'

<Steps
  items={[
    null, // Render nothing on first step
    <Notes>Foo</Notes>,
    <Notes>Bar</Notes>,
  ]}
/>
```