### PR TITLE
fix(loader): syntax errors in dev mode

### DIFF
--- a/packages/loader/index.js
+++ b/packages/loader/index.js
@@ -2,8 +2,7 @@ const { getOptions } = require('loader-utils')
 const mdx = require('@mdx-js/mdx')
 const mdxPlugin = require('@mdx-deck/mdx-plugin')
 
-module.exports = async function(src) {
-  const callback = this.async()
+module.exports = function(src) {
   const options = getOptions(this) || {}
   options.remarkPlugins = [
     ...options.remarkPlugins,
@@ -11,11 +10,8 @@ module.exports = async function(src) {
   ]
   options.remarkPlugins.push(mdxPlugin)
 
-  const result = mdx.sync(src, options)
-
-  const code = `/** @jsx mdx */
-  import { mdx } from '@mdx-js/react'
-  ${result}`
-
-  return callback(null, code)
+  const code = mdx.sync(src, options)
+  return `/** @jsx mdx */
+    import { mdx } from '@mdx-js/react'
+    ${code}`
 }


### PR DESCRIPTION
The dev server would silently hang when a syntax error was encountered in the @mdx-deck/loader module. You would only see the error after pressing ctrl+c to exit the process manually.

Before: https://streamable.com/7dpju
After: https://streamable.com/0jdz8