### PR TITLE
fix: keyboard controls after clicking button or link

### DIFF
--- a/packages/components/src/Keyboard.js
+++ b/packages/components/src/Keyboard.js
@@ -12,7 +12,7 @@ const keys = {
   pgDown: 34,
 }
 
-const inputElements = ['INPUT', 'TEXTAREA', 'A', 'BUTTON']
+const inputElements = ['INPUT', 'TEXTAREA']
 
 const toggleMode = key => state => ({
   mode: state.mode === key ? 'normal' : key,


### PR DESCRIPTION
Links and buttons shouldn't prevent keyboard navigation.