### PR TITLE
fix basePath issue on single deck site

### DIFF
--- a/packages/gatsby-theme/gatsby-node.js
+++ b/packages/gatsby-theme/gatsby-node.js
@@ -108,7 +108,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       component: DeckTemplate,
       context: {
         ...deck.node,
-        slug: '',
+        slug: basePath,
       },
     })
     return


### PR DESCRIPTION
When adding a custom basePath on a site with only one deck slide transitions move to the index path. `basePath` should be passed to context.

Here's a [repro](https://github.com/bkegley/gatsby-theme-mdx-deck-base-path)