### PR TITLE
Add @mdx-deck packages to gatsby config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry = https://registry.npmjs.com/

--- a/packages/mdx-deck/gatsby-config.js
+++ b/packages/mdx-deck/gatsby-config.js
@@ -12,7 +12,12 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-compile-es6-packages',
       options: {
-        modules: ['mdx-deck', '@mdx-deck/themes'],
+        modules: [
+          'mdx-deck',
+          '@mdx-deck/themes',
+          '@mdx-deck/layouts',
+          '@mdx-deck/components',
+        ],
       },
     },
   ],


### PR DESCRIPTION
Simple PR to allow using `@mdx-deck/components` and `@mdx-deck/layouts` in v3

Fixes: https://github.com/jxnblk/mdx-deck/issues/411