### PR TITLE
Update exporting.md

### DIFF
--- a/docs/exporting.md
+++ b/docs/exporting.md
@@ -13,13 +13,23 @@ add a `build` script to your `package.json` file.
 
 ## PDF
 
+The MDX server must be running during PDF export, add a `start` script to your `package.json` file.
+
+```json
+  "scripts": {
+    "start": "mdx-deck deck.mdx"
+  }
+```
+
 To export a deck as PDF, use the [`website-pdf`](https://www.npmjs.com/package/website-pdf) CLI.
-Start the MDX Deck dev server,
-then run the following command to create a PDF:
+
+Run the following command to create a PDF:
 
 ```sh
-npx website-pdf http://localhost:8000/print -o deck.pdf
+npx website-pdf http://localhost:<PORT>/print -o deck.pdf
 ```
+
+Note: `<PORT>` is the same port your MDX server is running on.
 
 ## PNG
 


### PR DESCRIPTION
The exporting documentation was not too straight forward. This is my attempt to help future users out.

I got tripped up on the following:
1. The phrase `MDX dev server` made me feel there was an actual `dev` script, but this was actually referring to the `start` script.
2. The docs assume the MDX server will be running on PORT 8000, but mine defaults to 8080. It took me a second to figure that out. A note about this would save a lot of future users out.