### PR TITLE
Add plugin to import code blocks from files

### DIFF
--- a/packages/gatsby-theme/gatsby-config.js
+++ b/packages/gatsby-theme/gatsby-config.js
@@ -1,6 +1,7 @@
 const IS_LOCAL = process.cwd() === __dirname
 
 const remarkPlugins = [require('remark-unwrap-images'), require('remark-emoji')]
+const gatsbyRemarkPlugins = [`gatsby-remark-import-code`]
 
 const config = (opts = {}) => {
   const { mdx = true, contentPath: name = 'decks' } = opts
@@ -17,6 +18,7 @@ const config = (opts = {}) => {
       mdx && {
         resolve: 'gatsby-plugin-mdx',
         options: {
+          gatsbyRemarkPlugins,
           remarkPlugins,
         },
       },

--- a/packages/gatsby-theme/package.json
+++ b/packages/gatsby-theme/package.json
@@ -32,6 +32,7 @@
     "gatsby-plugin-mdx": "^1.0.13",
     "gatsby-plugin-react-helmet": "^3.1.0",
     "gatsby-plugin-theme-ui": "^0.2.6",
+    "gatsby-remark-import-code": "^0.1.1",
     "gatsby-source-filesystem": "^2.1.3",
     "hhmmss": "^1.0.0",
     "lodash.get": "^4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6781,6 +6781,14 @@ gatsby-react-router-scroll@^2.1.6:
     scroll-behavior "^0.9.10"
     warning "^3.0.0"
 
+gatsby-remark-import-code@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-import-code/-/gatsby-remark-import-code-0.1.1.tgz#7cefff965f6f2c58685f7dab51359713e9f37bed"
+  integrity sha512-sFIgQbMlY5o3DHIHpVO8F4vca9JP1PHIZr9QtElDAPEzwSd5Bxig5OC/ztGhgmZtXpjX5/eazHtrsGwVdLZ6MQ==
+  dependencies:
+    shell-quote "^1.6.1"
+    unist-util-visit "^1.4.1"
+
 gatsby-source-filesystem@^2.1.3:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.6.tgz#ced6b7b9d02a74849ef2f5dce8d501839cd66e54"
@@ -13512,6 +13520,11 @@ shell-quote@1.6.1:
     array-map "~0.0.0"
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
+
+shell-quote@^1.6.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.1.tgz#3161d969886fb14f9140c65245a5dd19b6f0b06b"
+  integrity sha512-2kUqeAGnMAu6YrTPX4E3LfxacH9gKljzVjlkUeSqY0soGwK4KLl7TURXCem712tkhBCeeaFP9QK4dKn88s3Icg==
 
 shellwords@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Added [gatsby-remark-import-code](https://github.com/pomber/gatsby-remark-import-code) to the gatsby-plugin-mdx config.

This is particularly useful for people using Code Surfer, but it can also be used with any "vanilla" code block.  

It transforms code blocks from:

````md
```js file=./hello-world.js
```
````

into:

````md
```js
function helloWorld() {
  return "hello world";
}
```
````