### PR TITLE
Fix slug generation in windows

### DIFF
--- a/packages/gatsby-theme/gatsby-node.js
+++ b/packages/gatsby-theme/gatsby-node.js
@@ -163,8 +163,8 @@ exports.onCreateNode = ({ node, actions, getNode, createNodeId }) => {
   const { createNode, createParentChildLink } = actions
 
   const toPath = node => {
-    const { dir } = path.parse(node.relativePath)
-    return path.join(basePath, dir, node.name)
+    const { dir } = path.posix.parse(node.relativePath)
+    return path.posix.join(basePath, dir, node.name)
   }
 
   if (node.internal.type !== `Mdx`) return


### PR DESCRIPTION
When building on a windows machine, slugs maintain a windows path
format (i.e., slides were located at http://localhost:8000/\hello)

Forced npm path module to use posix formats to fix this.