### PR TITLE
Use correct path for print (fixes #440)

### DIFF
--- a/packages/gatsby-theme/gatsby-node.js
+++ b/packages/gatsby-theme/gatsby-node.js
@@ -116,7 +116,7 @@ exports.createPages = async ({ graphql, actions, reporter, pathPrefix }) => {
       },
     })
     createPage({
-      path: basePath + '/print',
+      path: base + '/print',
       component: DeckTemplate,
       context: {
         ...deck.node,


### PR DESCRIPTION
When the `basePath` is exactly `"/"` then the resulting path for printing is `//print`. See #440 

This PR makes sure there is no double slash reusing logic needed for matching unknown paths.