### PR TITLE
Use opt+f to go fullscreen

### DIFF
--- a/docs/presenting.md
+++ b/docs/presenting.md
@@ -6,6 +6,7 @@
 3. Move the new tab to its own window in the screen or projector that the audience sees
 4. Control the presentation from the original window
 5. Be sure to hide your mouse cursor so that it's not visible to the audience
+6. You can press `Opt + F` on the new tab to go fullscreen
 
 ## Speaker Notes
 

--- a/packages/gatsby-theme/src/hooks/use-keyboard.js
+++ b/packages/gatsby-theme/src/hooks/use-keyboard.js
@@ -13,6 +13,7 @@ const keys = {
   space: 32,
   p: 80,
   o: 79,
+  f: 70,
   g: 71,
   esc: 27,
   pageUp: 33,
@@ -62,6 +63,16 @@ export const useKeyboard = () => {
             break
           case keys.g:
             context.setState(toggleMode(modes.grid))
+            break
+          case keys.f:
+            const element = e.target
+
+            element.requestFullscreen =
+              element.requestFullscreen ||
+              element.mozRequestFullScreen ||
+              element.webkitRequestFullScreen
+
+            element.requestFullscreen()
             break
         }
       } else {


### PR DESCRIPTION
I was having trouble with going fullscreen on firefox (the navbar would not go away on fullscreen, not sure why), so I created this logic for a presentation myself.
I think it's a cool feature and could help others, so I created this PR.

I used a simple "polyfill" just in case, but I can change anything as desired, add more docs, etc :)