### PR TITLE
Improve handling of eject.

### DIFF
--- a/packages/mdx-deck/cli.js
+++ b/packages/mdx-deck/cli.js
@@ -96,10 +96,23 @@ switch (cmd) {
     })
     break
   case 'eject':
-    log('ejecting Gatsby site')
+    log('ejecting from mdx-deck into Gatsby site')
+    log('this can take a few minutes...')
     require('./eject')({
       cwd: process.cwd(),
-      filename: path.resolve(filename),
+      file: path.resolve(filename)
+    }).then(() => {
+      log('ejected successfully')
+      log(`you can now run the following commands:`)
+      console.log('');
+      console.log(`  ${chalk.cyan('npm start')}`)
+      console.log(`    starts the Gatsby development server`)
+      console.log('')
+      console.log(`  ${chalk.cyan('npm run build')}`)
+      console.log(`    creates a build of the Gatsby project`)
+      console.log('')
+      console.log(`  ${chalk.cyan('npm run clean')}`)
+      console.log(`    wipes the locally built gatby assets and cache`)
     }).catch(err => {
       log.error(err)
     })

--- a/packages/mdx-deck/eject.js
+++ b/packages/mdx-deck/eject.js
@@ -1,13 +1,55 @@
 const path = require('path')
 const fs = require('fs-extra')
-const initit = require('initit')
+const execa = require('execa')
 
-const template = 'jxnblk/mdx-deck/packages/starter'
+function updatePackageJson(cwd) {
+  const pkg = require(`${cwd}/package.json`)
 
-module.exports = async ({ cwd, filename }) => {
-  await initit({
-    template,
-    name: cwd,
-  })
-  fs.moveSync(filename, path.join(cwd, 'decks'))
+  pkg.private = true
+
+  delete pkg.devDependencies['mdx-deck']
+
+  pkg.dependencies = pkg.dependencies || {}
+  pkg.dependencies['gatsby'] = '^2.13.25'
+  pkg.dependencies['gatsby-theme-mdx-deck'] = '^3.0.13'
+  pkg.dependencies['react'] = '^16.8.6'
+  pkg.dependencies['react-dom'] = '^16.8.6'
+
+  pkg.scripts = pkg.scripts || {}
+  for (let i in pkg.scripts) {
+    if (/\bmdx-deck\b/.test(pkg.scripts[i])) {
+      delete pkg.scripts[i]
+    }
+  }
+  pkg.scripts.start = 'gatsby develop'
+  pkg.scripts.clean = 'gatsby clean'
+  pkg.scripts.build = 'gatsby build'
+
+  fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pkg, null, 2))
+}
+
+function createGatsbyConfig(cwd) {
+  const config = {
+    plugins: ['gatsby-theme-mdx-deck'],
+  }
+  const contents = `module.exports = ${JSON.stringify(config, null, 2)}`
+
+  fs.writeFileSync(path.join(cwd, 'gatsby-config.js'), contents)
+}
+
+function moveDeck(cwd, file) {
+  const filename = path.basename(file)
+  fs.moveSync(filename, path.join(cwd, 'decks', filename))
+}
+
+async function runNpmInstall(cwd) {
+  process.chdir(cwd)
+  await execa('npm', ['install'], { stdout: 'inherit', stderr: 'inherit' })
+}
+
+module.exports = async ({ cwd, file }) => {
+  updatePackageJson(cwd)
+  createGatsbyConfig(cwd)
+  moveDeck(cwd, file)
+  await runNpmInstall(cwd)
 }

--- a/packages/mdx-deck/package.json
+++ b/packages/mdx-deck/package.json
@@ -23,7 +23,6 @@
     "gatsby": "^2.13.24",
     "gatsby-plugin-compile-es6-packages": "^2.0.0",
     "gatsby-theme-mdx-deck": "^3.0.13",
-    "initit": "^1.0.0-2",
     "meow": "^5.0.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"


### PR DESCRIPTION
As discussed in [#511](https://github.com/jxnblk/mdx-deck/issues/511#issuecomment-541092796)

This is my initial stab at improving `eject`.

It removes `initit` as a dependency and instead manipulates the current working directory to look like [the starter](https://github.com/jxnblk/mdx-deck/tree/master/packages/starter) and uses `execa`, that was already a dependency, to run `npm install`.

Was it something like this you recommended @jxnblk ?

Fixes #511 