### PR TITLE
Update docs & examples to use v3 package imports

### DIFF
--- a/docs/demo.mdx
+++ b/docs/demo.mdx
@@ -3,7 +3,7 @@ import {
   Invert, Split, SplitRight, FullScreenCode, Horizontal
 } from 'mdx-deck'
 import Counter from './Counter'
-import { future } from '@mdx-deck/themes'
+import { future } from 'mdx-deck/themes'
 
 export const themes = [ future ]
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@emotion/core": "^10.0.7",
     "@emotion/styled": "^10.0.7",
-    "@mdx-deck/themes": "^3.0.8",
     "mdx-deck": "^3.0.13",
     "styled-system": "^5.0.15"
   }

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,9 +1,5 @@
 # Themes
 
-```sh
-npm i mdx-deck/themes
-```
-
 ![Default theme](images/default.png)
 
 ---

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,7 +1,7 @@
 # Themes
 
 ```sh
-npm i @mdx-deck/themes
+npm i mdx-deck/themes
 ```
 
 ![Default theme](images/default.png)
@@ -11,7 +11,7 @@ npm i @mdx-deck/themes
 ![Big theme](images/big.png)
 
 ```js
-import { big } from '@mdx-deck/themes'
+import { big } from 'mdx-deck/themes'
 ```
 
 ---
@@ -19,7 +19,7 @@ import { big } from '@mdx-deck/themes'
 ![Book theme](images/book.png)
 
 ```js
-import { book } from '@mdx-deck/themes'
+import { book } from 'mdx-deck/themes'
 ```
 
 ---
@@ -27,7 +27,7 @@ import { book } from '@mdx-deck/themes'
 ![Code theme](images/code.png)
 
 ```js
-import { code } from '@mdx-deck/themes'
+import { code } from 'mdx-deck/themes'
 ```
 
 ---
@@ -35,7 +35,7 @@ import { code } from '@mdx-deck/themes'
 ![Comic theme](images/comic.png)
 
 ```js
-import { comic } from '@mdx-deck/themes'
+import { comic } from 'mdx-deck/themes'
 ```
 
 ---
@@ -43,7 +43,7 @@ import { comic } from '@mdx-deck/themes'
 ![Condensed theme](images/condensed.png)
 
 ```js
-import { condensed } from '@mdx-deck/themes'
+import { condensed } from 'mdx-deck/themes'
 ```
 
 ---
@@ -51,7 +51,7 @@ import { condensed } from '@mdx-deck/themes'
 ![Dark theme](images/dark.png)
 
 ```js
-import { dark } from '@mdx-deck/themes'
+import { dark } from 'mdx-deck/themes'
 ```
 
 ---
@@ -59,7 +59,7 @@ import { dark } from '@mdx-deck/themes'
 ![Future theme](images/future.png)
 
 ```js
-import { future } from '@mdx-deck/themes'
+import { future } from 'mdx-deck/themes'
 ```
 
 ---
@@ -67,7 +67,7 @@ import { future } from '@mdx-deck/themes'
 ![Hack theme](images/hack.png)
 
 ```js
-import { hack } from '@mdx-deck/themes'
+import { hack } from 'mdx-deck/themes'
 ```
 
 ---
@@ -75,7 +75,7 @@ import { hack } from '@mdx-deck/themes'
 ![Notes theme](images/notes.png)
 
 ```js
-import { notes } from '@mdx-deck/themes'
+import { notes } from 'mdx-deck/themes'
 ```
 
 ---
@@ -83,7 +83,7 @@ import { notes } from '@mdx-deck/themes'
 ![Script theme](images/script.png)
 
 ```js
-import { script } from '@mdx-deck/themes'
+import { script } from 'mdx-deck/themes'
 ```
 
 ---
@@ -91,7 +91,7 @@ import { script } from '@mdx-deck/themes'
 ![Swiss theme](images/swiss.png)
 
 ```js
-import { swiss } from '@mdx-deck/themes'
+import { swiss } from 'mdx-deck/themes'
 ```
 
 ---
@@ -99,7 +99,7 @@ import { swiss } from '@mdx-deck/themes'
 ![Yellow theme](images/yellow.png)
 
 ```js
-import { yellow } from '@mdx-deck/themes'
+import { yellow } from 'mdx-deck/themes'
 ```
 
 ---
@@ -107,7 +107,7 @@ import { yellow } from '@mdx-deck/themes'
 Poppins
 
 ```js
-import { poppins } from '@mdx-deck/themes'
+import { poppins } from 'mdx-deck/themes'
 ```
 
 ---
@@ -115,7 +115,7 @@ import { poppins } from '@mdx-deck/themes'
 Syntax Highlighting
 
 ```js
-import { highlight } from '@mdx-deck/themes'
-import { prism } from '@mdx-deck/themes'
+import { highlight } from 'mdx-deck/themes'
+import { prism } from 'mdx-deck/themes'
 ```
 

--- a/examples/aspect-ratio/deck.mdx
+++ b/examples/aspect-ratio/deck.mdx
@@ -1,5 +1,4 @@
-import future from '@mdx-deck/themes/future'
-import aspect from '@mdx-deck/themes/aspect'
+import { future, aspect } from 'mdx-deck/themes'
 
 export const themes = [
   future,

--- a/examples/head/deck.mdx
+++ b/examples/head/deck.mdx
@@ -1,4 +1,4 @@
-import { Head } from '@mdx-deck/components'
+import { Head } from 'mdx-deck'
 
 <Head>
   <title>Hello</title>

--- a/examples/images/deck.mdx
+++ b/examples/images/deck.mdx
@@ -1,6 +1,6 @@
 import {
   Image,
-} from '@mdx-deck/components'
+} from 'mdx-deck'
 
 # Hello!
 

--- a/examples/layouts/deck.mdx
+++ b/examples/layouts/deck.mdx
@@ -4,7 +4,7 @@ import {
   SplitRight,
   Horizontal,
   FullScreenCode,
-} from '@mdx-deck/layouts'
+} from 'mdx-deck'
 
 # Hello!
 

--- a/examples/prism/deck.mdx
+++ b/examples/prism/deck.mdx
@@ -1,9 +1,8 @@
-import future from '@mdx-deck/themes/future'
-import highlight from '@mdx-deck/themes/syntax-highlighter-prism'
+import { future, prism } from 'mdx-deck/themes'
 
 export const themes = [
   future,
-  highlight
+  prism
 ]
 
 # Hello!

--- a/examples/provider/deck.mdx
+++ b/examples/provider/deck.mdx
@@ -1,4 +1,4 @@
-import comic from '@mdx-deck/themes/comic'
+import { comic } from 'mdx-deck/themes'
 import theme from './theme'
 
 export const themes = [

--- a/examples/syntax-highlighting/deck.mdx
+++ b/examples/syntax-highlighting/deck.mdx
@@ -1,5 +1,4 @@
-import future from '@mdx-deck/themes/future'
-import highlight from '@mdx-deck/themes/syntax-highlighter'
+import { future, highlight } from 'mdx-deck/themes'
 
 export const themes = [
   future,

--- a/examples/themes/theme.js
+++ b/examples/themes/theme.js
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react'
 import { ThemeProvider } from 'emotion-theming'
 import { MDXProvider } from '@mdx-js/react'
-import * as themes from '@mdx-deck/themes'
+import * as themes from 'mdx-deck/themes'
 
 const names = Object.keys(themes)
 
@@ -35,16 +35,14 @@ const Provider = props => {
           right: 0,
           bottom: 0,
           margin: 16,
-        }}
-      >
+        }}>
         <label>
           Theme
           <select
             value={name}
             onChange={e => {
               setTheme(e.target.value)
-            }}
-          >
+            }}>
             {names.map(name => (
               <option key={name}>{name}</option>
             ))}


### PR DESCRIPTION
This fixes the docs pages and examples that still used the incorrect v2 package names (`@mdx-deck/themes`, `@mdx-deck/components`).