### PR TITLE
Allows the usage of slide index in print mode

### DIFF
--- a/packages/gatsby-theme/src/components/deck.js
+++ b/packages/gatsby-theme/src/components/deck.js
@@ -37,7 +37,7 @@ const Print = ({ slides }) => {
   return (
     <Context.Provider value={context}>
       {slides.map((slide, i) => (
-        <Slide key={i} slide={slide} preview />
+        <Slide key={i} slide={slide} preview index={i} />
       ))}
     </Context.Provider>
   )


### PR DESCRIPTION
Refers to #374 

Allows to retrieve the slides index using the `useDeck` hook on print mode. Previously the value was always 0, because on the `Print` component, the slide index is not passed to the `Slide` component.