### PR TITLE
Using constant for normal mode on step 0

### DIFF
--- a/packages/gatsby-theme/src/components/app.js
+++ b/packages/gatsby-theme/src/components/app.js
@@ -1,6 +1,7 @@
 import React, { useReducer } from 'react'
 import merge from 'lodash.merge'
 import Context from '../context'
+import { modes } from '../constants'
 
 const reducer = (state, next) =>
   typeof next === 'function'
@@ -9,7 +10,7 @@ const reducer = (state, next) =>
 
 export default props => {
   const [state, setState] = useReducer(reducer, {
-    mode: 'normal',
+    mode: modes.normal,
     step: 0,
     metadata: {},
   })


### PR DESCRIPTION
I came across this issue when I was developing a theme, and I was checking if the user was in "normal" mode, I saw that it starts with "normal", but if you hit `escape`, it becomes "NORMAL", capitalised.

I checked the code and found out that the constants are not used on the `app.js`,  so I fixed it.