### PR TITLE
Fix website-pdf CLI flags defaults

### DIFF
--- a/packages/website-pdf/cli.js
+++ b/packages/website-pdf/cli.js
@@ -26,12 +26,12 @@ const cli = meow(
       width: {
         type: 'string',
         alias: 'w',
-        default: 1280,
+        default: '1280',
       },
       height: {
         type: 'string',
         alias: 'h',
-        default: 960,
+        default: '960',
       },
       sandbox: {
         type: 'boolean',


### PR DESCRIPTION
## Context
While trying to export an mdx deck presentation using the `website-pdf` package, I got the following error:

```sh
yarn run v1.21.1
$ ./cli.js http://localhost:8000/print -o ../../docs/dist
/Users/gregoiremielle/Documents/dev/mdx-deck/packages/website-pdf/node_modules/minimist-options/index.js:74
					throw new TypeError(`Expected "${key}" default value to be ${type}, got ${typeof props.default}`);
					^

TypeError: Expected "width" default value to be string, got number
    at Object.keys.forEach.key (/Users/gregoiremielle/Documents/dev/mdx-deck/packages/website-pdf/node_modules/minimist-options/index.js:74:12)
    at Array.forEach (<anonymous>)
    at buildOptions (/Users/gregoiremielle/Documents/dev/mdx-deck/packages/website-pdf/node_modules/minimist-options/index.js:36:23)
    at meow (/Users/gregoiremielle/Documents/dev/mdx-deck/packages/website-pdf/node_modules/meow/index.js:65:20)
    at Object.<anonymous> (/Users/gregoiremielle/Documents/dev/mdx-deck/packages/website-pdf/cli.js:5:13)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Indeed, it looks like because the type for `width` & `height` flags is `string` and default values are numbers, the `meow` package is complaining about types.

## Solution
This PR updates the default values to use strings instead of numbers.

- [x] Tests running in the `website-pdf` package
- [x] Export successful