### PR TITLE
Fix markdown syntax for example deck.

### DIFF
--- a/packages/mdx-deck/README.md
+++ b/packages/mdx-deck/README.md
@@ -226,7 +226,7 @@ See how others have used MDX Deck for their presentations.
 - [Stop de #divFest][stop-div-fest] by [Sara Vieira](https://mobile.twitter.com/NikkitaFTW)
 - [MDX, authors and richer JAMstack content][mdx-talk] by [Josh Dzielak](https://mobile.twitter.com/dzello)
 - [Components as Data: A Cross Platform GraphQL Powered Component API][components-as-data] by [Luke Herrington](https://mobile.twitter.com/lukeherrington)
-- [A short history of webdevs future 🔮][webdev-intro] by [Hendrik Wallbaum][https://github.com/hoverbaum]
+- [A short history of webdevs future 🔮][webdev-intro] by [Hendrik Wallbaum](https://github.com/hoverbaum)
 
 ### Usage Examples
 


### PR DESCRIPTION
The last pull request introduce a wrong markdown syntax leading to a weird output of link-text and link instead of a text that is a link.

This Pull Request fixes that.

Sorry for the inconvinience.