### PR TITLE
Ignore shortcuts when elements are focused

### DIFF
--- a/packages/gatsby-plugin/src/keyboard.js
+++ b/packages/gatsby-plugin/src/keyboard.js
@@ -16,6 +16,8 @@ const keys = {
   pageDown: 34,
 }
 
+const inputElements = ['input', 'select', 'textarea', 'a', 'button']
+
 export const useKeyboard = () => {
   const context = useDeck()
 
@@ -23,6 +25,10 @@ export const useKeyboard = () => {
     const handleKeyDown = e => {
       if (e.metaKey) return
       if (e.ctrlKey) return
+      
+      // ignore custom keyboard shortcuts when elements are focused
+      const el = document.activeElement.tagName.toLowerCase()
+      if (inputElements.includes(el)) return
 
       if (e.altKey) {
         switch (e.keyCode) {


### PR DESCRIPTION
Was trying to add inputs to slide deck and keyboard shortcuts kept moving to the next slide. This code is also in gatsby-theme so I just moved it to also be in gatsby-plugin.

I added this code and tested it locally and it works 

Let me know what you think and if there any other additional things I need to do.