### PR TITLE
fix: Stop slides keyboard navigation if user might be typing

### DIFF
--- a/packages/gatsby-plugin/src/keyboard.js
+++ b/packages/gatsby-plugin/src/keyboard.js
@@ -16,6 +16,8 @@ const keys = {
   pageDown: 34,
 }
 
+const inputElements = ['input', 'select', 'textarea', 'a', 'button']
+
 export const useKeyboard = () => {
   const context = useDeck()
 
@@ -23,6 +25,10 @@ export const useKeyboard = () => {
     const handleKeyDown = e => {
       if (e.metaKey) return
       if (e.ctrlKey) return
+
+      // ignore custom keyboard shortcuts when elements are focused
+      const el = document.activeElement.tagName.toLowerCase()
+      if (inputElements.includes(el)) return
 
       if (e.altKey) {
         switch (e.keyCode) {


### PR DESCRIPTION
This stops keyboard navigation if user has input / textarea focused and might be typing.

Basically a copy-paste from https://github.com/jxnblk/mdx-deck/blob/d3cea6b44a1f252432313ac4f6a5a7cc4f5844a6/packages/gatsby-theme/src/hooks/use-keyboard.js#L41-L43 which made me wondering why there are 2 versions of hooks etc.

PS: I'm using stand-alone version of mdx-deck it has this bug still.