### PR TITLE
feat: add url prefix to CLI

### DIFF
--- a/packages/gatsby-plugin/gatsby-node.js
+++ b/packages/gatsby-plugin/gatsby-node.js
@@ -41,27 +41,23 @@ exports.onCreateWebpackConfig = ({
               loader: '@mdx-js/loader',
               options: {
                 remarkPlugins,
-              }
+              },
             },
-          ]
-        }
-      ]
-    }
+          ],
+        },
+      ],
+    },
   })
 }
 
 exports.resolvableExtensions = () => ['.mdx']
 
-exports.createPages = ({
-  actions,
-}, {
-  path: source,
-} = {}) => {
+exports.createPages = ({ actions }, { path: source, url = '/' } = {}) => {
   if (!source) return
 
   actions.createPage({
-    path: '/',
-    matchPath: '/*',
+    path: url,
+    matchPath: url === '/' ? '/*' : `${url}/*`,
     component: source,
   })
 }

--- a/packages/gatsby-plugin/gatsby-node.js
+++ b/packages/gatsby-plugin/gatsby-node.js
@@ -52,12 +52,12 @@ exports.onCreateWebpackConfig = ({
 
 exports.resolvableExtensions = () => ['.mdx']
 
-exports.createPages = ({ actions }, { path: source, url = '/' } = {}) => {
+exports.createPages = ({ actions }, { path: source, url = '' } = {}) => {
   if (!source) return
 
   actions.createPage({
-    path: url,
-    matchPath: url === '/' ? '/*' : `${url}/*`,
+    path: `/${url}`,
+    matchPath: `${url}/*`,
     component: source,
   })
 }

--- a/packages/gatsby-plugin/src/deck.js
+++ b/packages/gatsby-plugin/src/deck.js
@@ -23,9 +23,8 @@ export default props => {
   const slide = slides[index]
 
   const [mode, setMode] = React.useState(modes.default)
-  const toggleMode = next => setMode(current =>
-    current === next ? modes.default : next
-  )
+  const toggleMode = next =>
+    setMode(current => (current === next ? modes.default : next))
 
   const [step, setStep] = React.useState(0)
   const [steps, setSteps] = React.useState(0)
@@ -38,18 +37,19 @@ export default props => {
   }, [index])
 
   React.useEffect(() => {
-    if (props.location.pathname === '/print') return
-    props.navigate('/#' + index, {
+    if (props.location.pathname.includes('/print')) return
+
+    props.navigate(props.location.pathname + '/#' + index, {
       replace: true,
     })
   }, [index])
 
   React.useEffect(() => {
-    if (props.location.pathname === '/print') {
+    if (props.location.pathname.includes('/print')) {
       setMode(modes.print)
     }
     if (!slide) {
-      props.navigate('/')
+      props.navigate(props.location.pathname)
       setIndex(0)
     }
   }, [])
@@ -80,7 +80,7 @@ export default props => {
     if (steps && step > 0) {
       setStep(n => n - 1)
     } else {
-      setIndex(n => n > 0 ? n - 1 : n)
+      setIndex(n => (n > 0 ? n - 1 : n))
       setStep(0)
       setSteps(0)
     }
@@ -90,7 +90,7 @@ export default props => {
     if (step < steps) {
       setStep(n => n + 1)
     } else {
-      setIndex(n => n < slides.length - 1 ? n + 1 : n)
+      setIndex(n => (n < slides.length - 1 ? n + 1 : n))
       setStep(0)
       setSteps(0)
     }
@@ -104,15 +104,11 @@ export default props => {
       <Storage />
       <Helmet>
         {slides.head.children}
-        {theme.googleFont && <link rel='stylesheet' href={theme.googleFont} />}
+        {theme.googleFont && <link rel="stylesheet" href={theme.googleFont} />}
       </Helmet>
-      <ThemeProvider
-        theme={theme}
-        components={theme.components}>
+      <ThemeProvider theme={theme} components={theme.components}>
         <Container>
-          <Slide>
-            {slide}
-          </Slide>
+          <Slide>{slide}</Slide>
         </Container>
       </ThemeProvider>
     </Context.Provider>

--- a/packages/gatsby-plugin/src/deck.js
+++ b/packages/gatsby-plugin/src/deck.js
@@ -39,7 +39,7 @@ export default props => {
   React.useEffect(() => {
     if (props.location.pathname.includes('/print')) return
 
-    props.navigate(props.location.pathname + '/#' + index, {
+    props.navigate(props.location.pathname + '#' + index, {
       replace: true,
     })
   }, [index])

--- a/packages/gatsby-plugin/test/deck.js
+++ b/packages/gatsby-plugin/test/deck.js
@@ -1,39 +1,28 @@
 import React from 'react'
-import {
-  render,
-  fireEvent,
-  cleanup
-} from '@testing-library/react'
+import { render, fireEvent, cleanup } from '@testing-library/react'
 import Deck from '../src/deck'
-import {
-  Steps,
-  Header,
-  Footer,
-} from '../src'
+import { Steps, Header, Footer } from '../src'
 
 afterEach(cleanup)
 
 let __key = 0
-const Comp = ({
-  originalType,
-  mdxType,
-  ...props
-}) => React.createElement(originalType, props)
+const Comp = ({ originalType, mdxType, ...props }) =>
+  React.createElement(originalType, props)
 
 const x = (tag, props, children) =>
-  React.createElement(Comp, {
-    key: __key++,
-    tag,
-    originalType: tag,
-    mdxType: tag,
-    ...props
-  }, children)
+  React.createElement(
+    Comp,
+    {
+      key: __key++,
+      tag,
+      originalType: tag,
+      mdxType: tag,
+      ...props,
+    },
+    children
+  )
 
-const mdx = [
-  x('div', null, 'One'),
-  x('hr', null),
-  x('div', null, 'Two'),
-]
+const mdx = [x('div', null, 'One'), x('hr', null), x('div', null, 'Two')]
 
 const deckProps = {
   children: mdx,
@@ -41,21 +30,17 @@ const deckProps = {
     hash: '',
     pathname: '/',
   },
-  navigate: jest.fn()
+  navigate: jest.fn(),
 }
 
 test('renders', () => {
-  const tree = render(
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   const text = tree.getByText('One')
   expect(text).toBeTruthy()
 })
 
 test('advances one slide with right arrow key', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
     keyCode: 39,
   })
@@ -64,9 +49,7 @@ test('advances one slide with right arrow key', () => {
 })
 
 test('advances one slide with down arrow key', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
     keyCode: 40,
   })
@@ -75,9 +58,7 @@ test('advances one slide with down arrow key', () => {
 })
 
 test('advances one slide with spacebar key', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
     keyCode: 32,
   })
@@ -86,9 +67,7 @@ test('advances one slide with spacebar key', () => {
 })
 
 test('advances one slide with page down key', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
     keyCode: 34,
   })
@@ -97,11 +76,12 @@ test('advances one slide with page down key', () => {
 })
 
 test('goes back one slide with left arrow key', () => {
-  const tree =render (
+  const tree = render(
     <Deck
       {...deckProps}
       location={{
         hash: '#2',
+        pathname: '/',
       }}
     />
   )
@@ -113,11 +93,12 @@ test('goes back one slide with left arrow key', () => {
 })
 
 test('goes back one slide with up arrow key', () => {
-  const tree =render (
+  const tree = render(
     <Deck
       {...deckProps}
       location={{
         hash: '#2',
+        pathname: '/',
       }}
     />
   )
@@ -129,11 +110,12 @@ test('goes back one slide with up arrow key', () => {
 })
 
 test('goes back one slide with page up key', () => {
-  const tree =render (
+  const tree = render(
     <Deck
       {...deckProps}
       location={{
         hash: '#2',
+        pathname: '/',
       }}
     />
   )
@@ -145,11 +127,12 @@ test('goes back one slide with page up key', () => {
 })
 
 test('goes back one slide with shift + space bar', () => {
-  const tree =render (
+  const tree = render(
     <Deck
       {...deckProps}
       location={{
         hash: '#2',
+        pathname: '/',
       }}
     />
   )
@@ -162,9 +145,7 @@ test('goes back one slide with shift + space bar', () => {
 })
 
 test('ignores meta keys', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
     metaKey: true,
     keyCode: 39,
@@ -174,9 +155,7 @@ test('ignores meta keys', () => {
 })
 
 test('ignores ctrl keys', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
     ctrlKey: true,
     keyCode: 39,
@@ -186,12 +165,12 @@ test('ignores ctrl keys', () => {
 })
 
 test('initializes print mode', () => {
-  const tree =render (
+  const tree = render(
     <Deck
       {...deckProps}
       location={{
         hash: '',
-        pathname: '/print'
+        pathname: '/print',
       }}
     />
   )
@@ -203,7 +182,9 @@ test('initializes print mode', () => {
 
 describe('steps', () => {
   const children = [
-    x('div', null,
+    x(
+      'div',
+      null,
       <Steps>
         <div>A</div>
         <div>B</div>
@@ -215,12 +196,7 @@ describe('steps', () => {
   ]
 
   test('increments step', () => {
-    const tree =render (
-      <Deck
-        {...deckProps}
-        children={children}
-      />
-    )
+    const tree = render(<Deck {...deckProps} children={children} />)
     fireEvent.keyDown(document.body, {
       keyCode: 39,
     })
@@ -231,12 +207,7 @@ describe('steps', () => {
   })
 
   test('decrements step', () => {
-    const tree =render (
-      <Deck
-        {...deckProps}
-        children={children}
-      />
-    )
+    const tree = render(<Deck {...deckProps} children={children} />)
     fireEvent.keyDown(document.body, { keyCode: 39 })
     fireEvent.keyDown(document.body, { keyCode: 39 })
     fireEvent.keyDown(document.body, { keyCode: 37 })
@@ -255,12 +226,7 @@ test('renders with Header and Footer', () => {
     x('hr', null),
     x('div', null, 'Two'),
   ]
-  const tree =render (
-    <Deck
-      {...deckProps}
-      children={children}
-    />
-  )
+  const tree = render(<Deck {...deckProps} children={children} />)
   const header = tree.getByText('Header')
   const footer = tree.getByText('Footer')
   expect(header).toBeTruthy()

--- a/packages/mdx-deck/cli.js
+++ b/packages/mdx-deck/cli.js
@@ -25,6 +25,7 @@ const cli = meow(
 
       -h --host     Dev server host
       -p --port     Dev server port
+      -u --url      Talk url prefix
       --no-open     Prevent from opening in default browser
 
 `,
@@ -41,6 +42,11 @@ const cli = meow(
         alias: 'h',
         default: 'localhost',
       },
+      url: {
+        type: 'string',
+        alias: 'u',
+        default: '/',
+      },
       open: {
         type: 'boolean',
         alias: 'o',
@@ -55,10 +61,10 @@ const filename = file || cmd
 
 if (!filename) cli.showHelp(0)
 
-process.env.__SRC__ = path.resolve(filename)
-
 const opts = Object.assign({}, cli.flags)
 
+process.env.__SRC__ = path.resolve(filename)
+process.env.__URL__ = opts.url
 let dev
 
 const gatsby = async (...args) => {

--- a/packages/mdx-deck/cli.js
+++ b/packages/mdx-deck/cli.js
@@ -45,7 +45,7 @@ const cli = meow(
       url: {
         type: 'string',
         alias: 'u',
-        default: '/',
+        default: '',
       },
       open: {
         type: 'boolean',

--- a/packages/mdx-deck/gatsby-config.js
+++ b/packages/mdx-deck/gatsby-config.js
@@ -1,6 +1,7 @@
 const path = require('path')
 
 const src = process.env.__SRC__
+const url = process.env.__URL__
 const dirname = path.dirname(src)
 
 module.exports = {
@@ -9,6 +10,7 @@ module.exports = {
       resolve: '@mdx-deck/gatsby-plugin',
       options: {
         path: src,
+        url,
         dirname,
       },
     },
@@ -16,11 +18,7 @@ module.exports = {
       resolve: 'gatsby-source-filesystem',
       options: {
         path: dirname,
-        ignore: [
-          'node_modules',
-          'public',
-          '.cache',
-        ]
+        ignore: ['node_modules', 'public', '.cache'],
       },
     },
     {

--- a/packages/mdx-deck/package.json
+++ b/packages/mdx-deck/package.json
@@ -7,7 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "start": "./cli.js hello.mdx",
+    "start": "./cli.js hello.mdx -u /test",
     "build": "./cli.js build hello.mdx",
     "help": "./cli.js"
   },

--- a/packages/mdx-deck/package.json
+++ b/packages/mdx-deck/package.json
@@ -7,7 +7,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "start": "./cli.js hello.mdx -u /test",
+    "start": "./cli.js hello.mdx",
     "build": "./cli.js build hello.mdx",
     "help": "./cli.js"
   },


### PR DESCRIPTION
## What is this pr about? 👀

Currently, the project only allows creating the slides under `/`. This PR adds the feature of sending the `url` (basePath) as a CLI parameter. Which then it's taken by Gatsby when it creates the pages.

## Changes 🎁
- [x] Add CLI parameter and add to the CLI documentation.
- [x] Change gatsby-config inside `mdx-deck` and `gatsby-plugin`
- [x] Change navigation logic inside `decks.js`