### PR TITLE
Fix/improve themes examples

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -7,7 +7,8 @@
 ![Big theme](images/big.png)
 
 ```js
-import { big } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.big
 ```
 
 ---
@@ -15,7 +16,8 @@ import { big } from 'mdx-deck/themes'
 ![Book theme](images/book.png)
 
 ```js
-import { book } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.book
 ```
 
 ---
@@ -23,7 +25,8 @@ import { book } from 'mdx-deck/themes'
 ![Code theme](images/code.png)
 
 ```js
-import { code } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.code
 ```
 
 ---
@@ -31,7 +34,8 @@ import { code } from 'mdx-deck/themes'
 ![Comic theme](images/comic.png)
 
 ```js
-import { comic } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.comic
 ```
 
 ---
@@ -39,7 +43,8 @@ import { comic } from 'mdx-deck/themes'
 ![Condensed theme](images/condensed.png)
 
 ```js
-import { condensed } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.condensed
 ```
 
 ---
@@ -47,7 +52,8 @@ import { condensed } from 'mdx-deck/themes'
 ![Dark theme](images/dark.png)
 
 ```js
-import { dark } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.dark
 ```
 
 ---
@@ -55,7 +61,8 @@ import { dark } from 'mdx-deck/themes'
 ![Future theme](images/future.png)
 
 ```js
-import { future } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.future
 ```
 
 ---
@@ -63,7 +70,8 @@ import { future } from 'mdx-deck/themes'
 ![Hack theme](images/hack.png)
 
 ```js
-import { hack } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.hack
 ```
 
 ---
@@ -71,7 +79,8 @@ import { hack } from 'mdx-deck/themes'
 ![Notes theme](images/notes.png)
 
 ```js
-import { notes } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.notes
 ```
 
 ---
@@ -79,7 +88,8 @@ import { notes } from 'mdx-deck/themes'
 ![Script theme](images/script.png)
 
 ```js
-import { script } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.script
 ```
 
 ---
@@ -87,7 +97,8 @@ import { script } from 'mdx-deck/themes'
 ![Swiss theme](images/swiss.png)
 
 ```js
-import { swiss } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.swiss
 ```
 
 ---
@@ -95,7 +106,8 @@ import { swiss } from 'mdx-deck/themes'
 ![Yellow theme](images/yellow.png)
 
 ```js
-import { yellow } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.yellow
 ```
 
 ---
@@ -103,6 +115,7 @@ import { yellow } from 'mdx-deck/themes'
 Poppins
 
 ```js
-import { poppins } from 'mdx-deck/themes'
+import { themes } from 'mdx-deck'
+export const theme = themes.poppins
 ```
 


### PR DESCRIPTION
It took me a bit to figure out how to change then theme, as I was looking first at the examples and missed that the `theme` const needs to be exported as well.

I kinda prefer importing the whole `themes` object from `'mdx-deck'`, but I also like the previous style of importing only the theme which is actually used. If that's preferred, I guess the package name changed recently and we would need to do something like:

```js
import { big } from '@mdx-deck/themes'
export const theme = big
```