### PR TITLE
Replace deprecated `KeyboardEvent.keyCode` by `KeyboardEvent.code`

### DIFF
--- a/cypress/integration/hello.js
+++ b/cypress/integration/hello.js
@@ -15,7 +15,7 @@ context('MDX Deck', () => {
   it('goes to the next slide', () => {
     cy.get('body')
       .trigger('keydown', {
-        keyCode: 39,
+        code: 'ArrowRight',
       })
       .contains('Presentation')
   })

--- a/packages/gatsby-plugin/src/keyboard.js
+++ b/packages/gatsby-plugin/src/keyboard.js
@@ -3,18 +3,32 @@ import { useDeck } from './context'
 import modes from './modes'
 
 const keys = {
-  right: 39,
-  left: 37,
-  up: 38,
-  down: 40,
-  space: 32,
-  p: 80,
-  o: 79,
-  g: 71,
-  esc: 27,
-  pageUp: 33,
-  pageDown: 34,
+  right: 'ArrowRight',
+  left: 'ArrowLeft',
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  space: 'Space',
+  p: 'KeyP',
+  o: 'KeyO',
+  g: 'KeyG',
+  esc: 'Escape',
+  pageUp: 'PageUp',
+  pageDown: 'PageDown',
 }
+
+// const keys = {
+//   right: 39,
+//   left: 37,
+//   up: 38,
+//   down: 40,
+//   space: 32,
+//   p: 80,
+//   o: 79,
+//   g: 71,
+//   esc: 27,
+//   pageUp: 33,
+//   pageDown: 34,
+// }
 
 export const useKeyboard = () => {
   const context = useDeck()
@@ -24,8 +38,10 @@ export const useKeyboard = () => {
       if (e.metaKey) return
       if (e.ctrlKey) return
 
+      console.log(e)
+
       if (e.altKey) {
-        switch (e.keyCode) {
+        switch (e.code) {
           case keys.p:
             if (e.shiftKey) {
               context.toggleMode(modes.print)
@@ -43,7 +59,7 @@ export const useKeyboard = () => {
             break
         }
       } else if (e.shiftKey) {
-        switch (e.keyCode) {
+        switch (e.code) {
           case keys.space:
             e.preventDefault()
             context.previous()
@@ -52,7 +68,7 @@ export const useKeyboard = () => {
             break
         }
       } else {
-        switch (e.keyCode) {
+        switch (e.code) {
           case keys.right:
           case keys.down:
           case keys.pageDown:

--- a/packages/gatsby-plugin/src/keyboard.js
+++ b/packages/gatsby-plugin/src/keyboard.js
@@ -16,20 +16,6 @@ const keys = {
   pageDown: 'PageDown',
 }
 
-// const keys = {
-//   right: 39,
-//   left: 37,
-//   up: 38,
-//   down: 40,
-//   space: 32,
-//   p: 80,
-//   o: 79,
-//   g: 71,
-//   esc: 27,
-//   pageUp: 33,
-//   pageDown: 34,
-// }
-
 export const useKeyboard = () => {
   const context = useDeck()
 

--- a/packages/gatsby-plugin/test/deck.js
+++ b/packages/gatsby-plugin/test/deck.js
@@ -85,7 +85,7 @@ test('goes back one slide with left arrow key', () => {
     />
   )
   fireEvent.keyDown(document.body, {
-    keyCode: 'ArrowLeft',
+    code: 'ArrowLeft',
   })
   const text = tree.getByText('One')
   expect(text).toBeTruthy()

--- a/packages/gatsby-plugin/test/deck.js
+++ b/packages/gatsby-plugin/test/deck.js
@@ -1,39 +1,28 @@
 import React from 'react'
-import {
-  render,
-  fireEvent,
-  cleanup
-} from '@testing-library/react'
+import { render, fireEvent, cleanup } from '@testing-library/react'
 import Deck from '../src/deck'
-import {
-  Steps,
-  Header,
-  Footer,
-} from '../src'
+import { Steps, Header, Footer } from '../src'
 
 afterEach(cleanup)
 
 let __key = 0
-const Comp = ({
-  originalType,
-  mdxType,
-  ...props
-}) => React.createElement(originalType, props)
+const Comp = ({ originalType, mdxType, ...props }) =>
+  React.createElement(originalType, props)
 
 const x = (tag, props, children) =>
-  React.createElement(Comp, {
-    key: __key++,
-    tag,
-    originalType: tag,
-    mdxType: tag,
-    ...props
-  }, children)
+  React.createElement(
+    Comp,
+    {
+      key: __key++,
+      tag,
+      originalType: tag,
+      mdxType: tag,
+      ...props,
+    },
+    children
+  )
 
-const mdx = [
-  x('div', null, 'One'),
-  x('hr', null),
-  x('div', null, 'Two'),
-]
+const mdx = [x('div', null, 'One'), x('hr', null), x('div', null, 'Two')]
 
 const deckProps = {
   children: mdx,
@@ -41,63 +30,53 @@ const deckProps = {
     hash: '',
     pathname: '/',
   },
-  navigate: jest.fn()
+  navigate: jest.fn(),
 }
 
 test('renders', () => {
-  const tree = render(
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   const text = tree.getByText('One')
   expect(text).toBeTruthy()
 })
 
 test('advances one slide with right arrow key', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
-    keyCode: 39,
+    code: 'ArrowRight',
   })
   const text = tree.getByText('Two')
   expect(text).toBeTruthy()
 })
 
 test('advances one slide with down arrow key', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
-    keyCode: 40,
+    code: 'ArrowDown',
   })
   const text = tree.getByText('Two')
   expect(text).toBeTruthy()
 })
 
 test('advances one slide with spacebar key', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
-    keyCode: 32,
+    code: 'Space',
   })
   const text = tree.getByText('Two')
   expect(text).toBeTruthy()
 })
 
 test('advances one slide with page down key', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
-    keyCode: 34,
+    code: 'PageDown',
   })
   const text = tree.getByText('Two')
   expect(text).toBeTruthy()
 })
 
 test('goes back one slide with left arrow key', () => {
-  const tree =render (
+  const tree = render(
     <Deck
       {...deckProps}
       location={{
@@ -106,14 +85,14 @@ test('goes back one slide with left arrow key', () => {
     />
   )
   fireEvent.keyDown(document.body, {
-    keyCode: 37,
+    keyCode: 'ArrowLeft',
   })
   const text = tree.getByText('One')
   expect(text).toBeTruthy()
 })
 
 test('goes back one slide with up arrow key', () => {
-  const tree =render (
+  const tree = render(
     <Deck
       {...deckProps}
       location={{
@@ -122,14 +101,14 @@ test('goes back one slide with up arrow key', () => {
     />
   )
   fireEvent.keyDown(document.body, {
-    keyCode: 38,
+    code: 'ArrowUp',
   })
   const text = tree.getByText('One')
   expect(text).toBeTruthy()
 })
 
 test('goes back one slide with page up key', () => {
-  const tree =render (
+  const tree = render(
     <Deck
       {...deckProps}
       location={{
@@ -138,14 +117,14 @@ test('goes back one slide with page up key', () => {
     />
   )
   fireEvent.keyDown(document.body, {
-    keyCode: 33,
+    code: 'PageUp',
   })
   const text = tree.getByText('One')
   expect(text).toBeTruthy()
 })
 
 test('goes back one slide with shift + space bar', () => {
-  const tree =render (
+  const tree = render(
     <Deck
       {...deckProps}
       location={{
@@ -155,43 +134,39 @@ test('goes back one slide with shift + space bar', () => {
   )
   fireEvent.keyDown(document.body, {
     shiftKey: true,
-    keyCode: 32,
+    code: 'Space',
   })
   const text = tree.getByText('One')
   expect(text).toBeTruthy()
 })
 
 test('ignores meta keys', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
     metaKey: true,
-    keyCode: 39,
+    code: 'ArrowRight',
   })
   const text = tree.getByText('One')
   expect(text).toBeTruthy()
 })
 
 test('ignores ctrl keys', () => {
-  const tree =render (
-    <Deck {...deckProps} />
-  )
+  const tree = render(<Deck {...deckProps} />)
   fireEvent.keyDown(document.body, {
     ctrlKey: true,
-    keyCode: 39,
+    code: 'ArrowRight',
   })
   const text = tree.getByText('One')
   expect(text).toBeTruthy()
 })
 
 test('initializes print mode', () => {
-  const tree =render (
+  const tree = render(
     <Deck
       {...deckProps}
       location={{
         hash: '',
-        pathname: '/print'
+        pathname: '/print',
       }}
     />
   )
@@ -203,7 +178,9 @@ test('initializes print mode', () => {
 
 describe('steps', () => {
   const children = [
-    x('div', null,
+    x(
+      'div',
+      null,
       <Steps>
         <div>A</div>
         <div>B</div>
@@ -215,14 +192,9 @@ describe('steps', () => {
   ]
 
   test('increments step', () => {
-    const tree =render (
-      <Deck
-        {...deckProps}
-        children={children}
-      />
-    )
+    const tree = render(<Deck {...deckProps} children={children} />)
     fireEvent.keyDown(document.body, {
-      keyCode: 39,
+      code: 'ArrowRight',
     })
     const a = tree.getByText('A')
     const b = tree.getByText('B')
@@ -231,15 +203,10 @@ describe('steps', () => {
   })
 
   test('decrements step', () => {
-    const tree =render (
-      <Deck
-        {...deckProps}
-        children={children}
-      />
-    )
-    fireEvent.keyDown(document.body, { keyCode: 39 })
-    fireEvent.keyDown(document.body, { keyCode: 39 })
-    fireEvent.keyDown(document.body, { keyCode: 37 })
+    const tree = render(<Deck {...deckProps} children={children} />)
+    fireEvent.keyDown(document.body, { code: 'ArrowRight' })
+    fireEvent.keyDown(document.body, { code: 'ArrowRight' })
+    fireEvent.keyDown(document.body, { code: 'ArrowLeft' })
     const a = tree.getByText('A')
     const b = tree.getByText('B')
     expect(a.style.visibility).toBe('visible')
@@ -255,12 +222,7 @@ test('renders with Header and Footer', () => {
     x('hr', null),
     x('div', null, 'Two'),
   ]
-  const tree =render (
-    <Deck
-      {...deckProps}
-      children={children}
-    />
-  )
+  const tree = render(<Deck {...deckProps} children={children} />)
   const header = tree.getByText('Header')
   const footer = tree.getByText('Footer')
   expect(header).toBeTruthy()

--- a/packages/gatsby-theme/src/hooks/use-keyboard.js
+++ b/packages/gatsby-theme/src/hooks/use-keyboard.js
@@ -6,17 +6,17 @@ import { modes } from '../constants'
 import { previous, next } from '../navigate'
 
 const keys = {
-  right: 39,
-  left: 37,
-  up: 38,
-  down: 40,
-  space: 32,
-  p: 80,
-  o: 79,
-  g: 71,
-  esc: 27,
-  pageUp: 33,
-  pageDown: 34,
+  right: 'ArrowRight',
+  left: 'ArrowLeft',
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  space: 'Space',
+  p: 'KeyP',
+  o: 'KeyO',
+  g: 'KeyG',
+  esc: 'Escape',
+  pageUp: 'PageUp',
+  pageDown: 'PageDown',
 }
 
 const toggleMode = next => state =>
@@ -43,7 +43,7 @@ export const useKeyboard = () => {
       if (inputElements.includes(el)) return
 
       if (shiftKey) {
-        switch (e.keyCode) {
+        switch (e.code) {
           case keys.space:
             previous(context)
             break
@@ -53,7 +53,7 @@ export const useKeyboard = () => {
             break
         }
       } else if (altKey) {
-        switch (e.keyCode) {
+        switch (e.code) {
           case keys.p:
             context.setState(toggleMode(modes.presenter))
             break
@@ -65,7 +65,7 @@ export const useKeyboard = () => {
             break
         }
       } else {
-        switch (e.keyCode) {
+        switch (e.code) {
           case keys.right:
           case keys.down:
           case keys.pageDown:


### PR DESCRIPTION
I was having some trouble trying to enter presenter mode by pressing `Option + P`. After some time banging my head on the keyboard, I noticed that actually it was an extension in my browser capturing the same shortcut to perform a Picture in Picture (so here's the tip for whoever might be facing the same issue in MacOS).

Since I was already with the project cloned in my machine, I decided to also do this replacing to remove the [deprecated `keyCode`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) field from KeyboardEvent, just to avoid it becoming a breaking change in the near future.